### PR TITLE
Add BZip2 codec (block + streaming), version 0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ To simplify instance creation, GrindCore provides:
 All native compression algorithms are directly built into the [GrindCore Native](https://github.com/Nanook/GrindCore) project—**no third-party binaries are used or required**. The following algorithms are compiled from source as part of the native library, ensuring full integration, security, and maintainability:
 
 - **Brotli** v1.1.0 (from [.NET 9.0](https://github.com/dotnet/runtime/tree/release/9.0/src/native/external/brotli))
+- **BZip2** v1.0.8 (from [bzip2](https://sourceware.org/git/?p=bzip2.git)) — supports multi-stream (concatenated) decompression
 - **Copy** (no compression - direct stream copy)
 - **LZ4** v1.10.0 (from [LZ4](https://github.com/lz4/lz4/tree/dev/lib))
 - **LZMA** v25.1.0 (from [7Zip](https://sourceforge.net/projects/sevenzip/files/7-Zip/25.01/) App)
@@ -88,7 +89,7 @@ All native compression algorithms are directly built into the [GrindCore Native]
 - Multiple versions of some algorithms (e.g., ZStd, ZLib/ZLib-NG) are included to support applications that require pinned or frozen versions, most commonly for scenarios demanding byte-perfect, deterministic outputs.
 - ZStd supports multithreaded compression via `ThreadCount` in `CompressionOptions`, enabling parallel compression using multiple worker threads for significantly higher throughput on multicore systems.
 - ZStd supports pre-trained dictionaries via `InitProperties` in `CompressionOptions` for improved compression of small data.
-- The set of supported algorithms will continue to expand, with Snappy and BZip2 planned for future releases.
+- The set of supported algorithms will continue to expand.
 - Both blocking and asynchronous methods are available, allowing flexible compression workflows.
 - Compression streams expose `.Position` (compressed) and `.PositionFullSize` (uncompressed) properties for accurate progress tracking.
 

--- a/src/BZip2/BZip2Block.cs
+++ b/src/BZip2/BZip2Block.cs
@@ -1,0 +1,133 @@
+using System;
+using static Nanook.GrindCore.Interop;
+using static Nanook.GrindCore.Interop.BZip2;
+
+namespace Nanook.GrindCore.BZip2
+{
+    /// <summary>
+    /// Provides a block-based implementation of the BZip2 compression algorithm.
+    /// </summary>
+    public class BZip2Block : CompressionBlock
+    {
+        private readonly int _blockSize100k;
+        private readonly int _workFactor;
+        private readonly int _small;
+
+        /// <summary>
+        /// Gets the required output buffer size for compression, as determined by bzip2's own
+        /// documented worst-case bound (source size + 1% + 600 bytes; see BZ2_bzBuffToBuffCompress
+        /// in bzlib.h).
+        /// </summary>
+        public override int RequiredCompressOutputSize { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BZip2Block"/> class with the specified compression options.
+        /// </summary>
+        /// <param name="options">The compression options to use.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> or <c>options.BlockSize</c> is null.</exception>
+        public BZip2Block(CompressionOptions options) : base(CompressionAlgorithm.BZip2, options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+            if (options.BlockSize == null)
+                throw new ArgumentNullException(nameof(options.BlockSize));
+
+            // bzip2's "level" is blockSize100k (1-9, 900k*n block size); it has no 0/no-compression
+            // concept, so clamp CompressionType (which may resolve to Level0/NoCompression via the
+            // base class) into bzip2's valid 1-9 range.
+            int level = (int)this.CompressionType;
+            _blockSize100k = level < 1 ? 1 : (level > 9 ? 9 : level);
+
+            _workFactor = options.Dictionary?.WorkFactor ?? 0;
+            _small = (options.Dictionary?.SmallDecompress ?? false) ? 1 : 0;
+
+            int sourceLen = (int)options.BlockSize!;
+            // bzlib.h's own documented bound: dest buffer must be at least 1% larger than the
+            // source, plus 600 extra bytes, to guarantee BZ2_bzBuffToBuffCompress never fails with
+            // BZ_OUTBUFF_FULL. Integer division truncates the 1%, so add 1 to stay on the safe side.
+            RequiredCompressOutputSize = sourceLen + (sourceLen / 100 + 1) + 600;
+        }
+
+        /// <summary>
+        /// Compresses the source data block into the destination data block using BZip2.
+        /// </summary>
+        /// <param name="srcData">The source data block to compress.</param>
+        /// <param name="dstData">The destination data block to write compressed data to.</param>
+        /// <param name="dstCount">On input, the maximum bytes available; on output, the actual bytes written.</param>
+        /// <returns>The compression result code.</returns>
+        internal unsafe override CompressionResultCode OnCompress(DataBlock srcData, DataBlock dstData, ref int dstCount)
+        {
+            fixed (byte* srcPtr = srcData.Data)
+            fixed (byte* dstPtr = dstData.Data)
+            {
+                byte* s = srcPtr + srcData.Offset;
+                byte* d = dstPtr + dstData.Offset;
+
+                UIntPtr dstCapacity = (UIntPtr)dstCount;
+                int result = SZ_BZip2_v1_0_8_CompressBlock(d, ref dstCapacity, s, (UIntPtr)srcData.Length, _blockSize100k, _workFactor);
+
+                if (result != BZ_OK)
+                {
+                    dstCount = 0;
+                    return mapResult(result);
+                }
+
+                dstCount = (int)dstCapacity;
+                return CompressionResultCode.Success;
+            }
+        }
+
+        /// <summary>
+        /// Decompresses the source data block into the destination data block using BZip2.
+        /// </summary>
+        /// <param name="srcData">The source data block to decompress.</param>
+        /// <param name="dstData">The destination data block to write decompressed data to.</param>
+        /// <param name="dstCount">On input, the maximum bytes available; on output, the actual bytes written.</param>
+        /// <returns>The compression result code.</returns>
+        internal unsafe override CompressionResultCode OnDecompress(DataBlock srcData, DataBlock dstData, ref int dstCount)
+        {
+            fixed (byte* srcPtr = srcData.Data)
+            fixed (byte* dstPtr = dstData.Data)
+            {
+                byte* s = srcPtr + srcData.Offset;
+                byte* d = dstPtr + dstData.Offset;
+
+                UIntPtr dstCapacity = (UIntPtr)dstCount;
+                int result = SZ_BZip2_v1_0_8_DecompressBlock(d, ref dstCapacity, s, (UIntPtr)srcData.Length, _small);
+
+                if (result != BZ_OK)
+                {
+                    dstCount = 0;
+                    return mapResult(result);
+                }
+
+                dstCount = (int)dstCapacity;
+                return CompressionResultCode.Success;
+            }
+        }
+
+        /// <summary>
+        /// Releases any resources used by the <see cref="BZip2Block"/>. No resources to release for BZip2 blocks.
+        /// </summary>
+        internal override void OnDispose()
+        {
+        }
+
+        private static CompressionResultCode mapResult(int code)
+        {
+            return code switch
+            {
+                BZ_OK => CompressionResultCode.Success,
+                BZ_SEQUENCE_ERROR => CompressionResultCode.Error,
+                BZ_PARAM_ERROR => CompressionResultCode.InvalidParameter,
+                BZ_MEM_ERROR => CompressionResultCode.Error,
+                BZ_DATA_ERROR => CompressionResultCode.InvalidData,
+                BZ_DATA_ERROR_MAGIC => CompressionResultCode.InvalidData,
+                BZ_UNEXPECTED_EOF => CompressionResultCode.InvalidData,
+                BZ_OUTBUFF_FULL => CompressionResultCode.InsufficientBuffer,
+                BZ_CONFIG_ERROR => CompressionResultCode.Error,
+                _ => CompressionResultCode.Error
+            };
+        }
+    }
+}

--- a/src/BZip2/BZip2Decoder.cs
+++ b/src/BZip2/BZip2Decoder.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using static Nanook.GrindCore.Interop;
+using static Nanook.GrindCore.Interop.BZip2;
+
+namespace Nanook.GrindCore.BZip2
+{
+    /// <summary>
+    /// Provides a wrapper around the BZip2 streaming decompression API, supporting transparent
+    /// decompression of concatenated ("multi-stream") .bz2 data - bzip2 has documented this
+    /// concatenation convention since 0.9.0 (the same way multiple gzip members can be
+    /// concatenated and decompress as one logical stream; see <c>DeflateDecoder</c>'s
+    /// <c>resetStreamForLeftoverInput</c> for the equivalent gzip-side handling).
+    /// </summary>
+    internal unsafe sealed class BZip2Decoder : IDisposable
+    {
+        private static readonly byte[] Bzip2MagicHeader = { (byte)'B', (byte)'Z', (byte)'h' };
+
+        // Must live at a single, never-moving address for its entire lifetime - see
+        // Interop.SZ_BZip2_v1_0_8_CompressionContext's doc comment (libbzip2 stores and validates
+        // the bz_stream* pointer across calls) and BZip2Encoder's matching field.
+        private IntPtr _ctx;
+        private readonly int _small;
+        private bool _finished;
+        private bool _nonEmptyInput;
+        private bool _isDisposed;
+
+        /// <summary>
+        /// Returns true if the end of the (possibly multi-stream) input has been reached.
+        /// </summary>
+        public bool Finished => _finished;
+
+        /// <summary>
+        /// Returns true if any non-empty input has ever been provided.
+        /// </summary>
+        public bool NonEmptyInput => _nonEmptyInput;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BZip2Decoder"/> class.
+        /// </summary>
+        /// <param name="smallDecompress">
+        /// When true, selects bzip2's reduced-memory decompression algorithm (~2.5x less memory, some speed cost).
+        /// </param>
+        /// <exception cref="Exception">Thrown if the native decompression context cannot be created.</exception>
+        public BZip2Decoder(bool smallDecompress)
+        {
+            _small = smallDecompress ? 1 : 0;
+            _ctx = Marshal.AllocHGlobal(Marshal.SizeOf<SZ_BZip2_v1_0_8_DecompressionContext>());
+            init();
+        }
+
+        private void init()
+        {
+            int result = SZ_BZip2_v1_0_8_CreateDecompressionContext(_ctx, _small);
+            if (result != BZ_OK)
+                throw new Exception($"Failed to create BZip2 decompression context (error {result})");
+        }
+
+        /// <summary>
+        /// Finalizer to ensure resources are released.
+        /// </summary>
+        ~BZip2Decoder()
+        {
+            dispose(false);
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="BZip2Decoder"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                SZ_BZip2_v1_0_8_FreeDecompressionContext(_ctx);
+                Marshal.FreeHGlobal(_ctx);
+                _isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if there is no available input to feed the decoder.
+        /// </summary>
+        public bool NeedsInput(CompressionBuffer inData) => inData.AvailableRead == 0;
+
+        /// <summary>
+        /// Decompresses available input from <paramref name="inData"/> into <paramref name="outData"/>.
+        /// If bzip2 reports the end of a stream and further input immediately looks like another
+        /// bzip2 header, the decoder transparently reinitializes and continues (multi-stream
+        /// concatenation); otherwise <see cref="Finished"/> becomes true.
+        /// </summary>
+        /// <param name="inData">The input buffer containing compressed data.</param>
+        /// <param name="outData">The output buffer to write decompressed data to.</param>
+        /// <param name="length">The maximum number of bytes to write. If 0, fills the available output space.</param>
+        /// <returns>The number of bytes written to <paramref name="outData"/>.</returns>
+        /// <exception cref="InvalidDataException">Thrown if the input data is corrupted or invalid.</exception>
+        public int DecodeData(CompressionBuffer inData, CompressionBuffer outData, int length)
+        {
+            outData.Tidy();
+
+            if (length == 0 || length > outData.AvailableWrite)
+                length = outData.AvailableWrite;
+
+            if (length == 0 || inData.AvailableRead == 0)
+                return 0;
+
+            _nonEmptyInput = true;
+
+            fixed (byte* inBase = inData.Data)
+            fixed (byte* outBase = outData.Data)
+            {
+                byte* srcPtr = inBase + inData.Pos;
+                byte* dstPtr = outBase + outData.Size;
+
+                int result = SZ_BZip2_v1_0_8_DecompressStream(
+                    _ctx, dstPtr, (UIntPtr)length,
+                    srcPtr, (UIntPtr)inData.AvailableRead,
+                    out long inSize, out long outSize);
+
+                if (result < 0)
+                    throw new InvalidDataException(SR.GenericInvalidData);
+
+                if (inSize > 0)
+                    inData.Read((int)inSize);
+                if (outSize > 0)
+                    outData.Write((int)outSize);
+
+                if (result == BZ_STREAM_END)
+                {
+                    if (inData.AvailableRead >= Bzip2MagicHeader.Length && looksLikeBzip2Header(inBase + inData.Pos))
+                    {
+                        SZ_BZip2_v1_0_8_FreeDecompressionContext(_ctx);
+                        init();
+                    }
+                    else
+                    {
+                        _finished = true;
+                    }
+                }
+
+                return (int)outSize;
+            }
+        }
+
+        private static bool looksLikeBzip2Header(byte* p)
+        {
+            for (int i = 0; i < Bzip2MagicHeader.Length; i++)
+                if (p[i] != Bzip2MagicHeader[i])
+                    return false;
+            return true;
+        }
+    }
+}

--- a/src/BZip2/BZip2Encoder.cs
+++ b/src/BZip2/BZip2Encoder.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Runtime.InteropServices;
+using static Nanook.GrindCore.Interop;
+using static Nanook.GrindCore.Interop.BZip2;
+
+namespace Nanook.GrindCore.BZip2
+{
+    /// <summary>
+    /// Provides a wrapper around the BZip2 streaming compression API. bzip2's bz_stream is
+    /// deliberately shaped like zlib's z_stream, so this mirrors <c>DeflateEncoder</c>'s shape
+    /// (one call drives one native step; the caller loops and drains output between calls) rather
+    /// than LZ4/LZMA's multi-call-per-invocation style.
+    /// </summary>
+    internal unsafe sealed class BZip2Encoder : IDisposable
+    {
+        // The context must live at a single, never-moving address for its entire lifetime -
+        // libbzip2 stores the bz_stream* passed to BZ2_bzCompressInit and rejects every later call
+        // whose pointer doesn't match exactly (see Interop.SZ_BZip2_v1_0_8_CompressionContext's
+        // doc comment). A managed struct field can be relocated by a compacting GC between separate
+        // P/Invoke calls, so the context is allocated in unmanaged memory instead.
+        private readonly IntPtr _ctx;
+        private bool _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BZip2Encoder"/> class with the specified
+        /// block size and work factor.
+        /// </summary>
+        /// <param name="blockSize100k">Block size, 1-9 (900k*n block size).</param>
+        /// <param name="workFactor">Work factor, 0-250 (0 = bzip2's own default).</param>
+        /// <exception cref="Exception">Thrown if the native compression context cannot be created.</exception>
+        public BZip2Encoder(int blockSize100k, int workFactor)
+        {
+            _ctx = Marshal.AllocHGlobal(Marshal.SizeOf<SZ_BZip2_v1_0_8_CompressionContext>());
+            int result = SZ_BZip2_v1_0_8_CreateCompressionContext(_ctx, blockSize100k, workFactor);
+            if (result != BZ_OK)
+            {
+                Marshal.FreeHGlobal(_ctx);
+                throw new Exception($"Failed to create BZip2 compression context (error {result})");
+            }
+        }
+
+        /// <summary>
+        /// Finalizer to ensure resources are released.
+        /// </summary>
+        ~BZip2Encoder()
+        {
+            dispose(false);
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="BZip2Encoder"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                SZ_BZip2_v1_0_8_FreeCompressionContext(_ctx);
+                Marshal.FreeHGlobal(_ctx);
+                _isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if there is no available input to feed the encoder.
+        /// </summary>
+        public bool NeedsInput(CompressionBuffer inData) => inData.AvailableRead == 0;
+
+        /// <summary>
+        /// Feeds available input to the encoder (BZ_RUN) and writes any produced output to outData.
+        /// A single native call may not consume/produce everything available; callers loop while
+        /// input and output space both remain.
+        /// </summary>
+        /// <param name="inData">The input buffer containing data to compress.</param>
+        /// <param name="outData">The output buffer to write compressed data to.</param>
+        /// <returns>The number of bytes written to <paramref name="outData"/>.</returns>
+        /// <exception cref="Exception">Thrown if the native compress step reports an error.</exception>
+        public int EncodeData(CompressionBuffer inData, CompressionBuffer outData)
+        {
+            outData.Tidy();
+
+            if (inData.AvailableRead == 0 || outData.AvailableWrite == 0)
+                return 0;
+
+            fixed (byte* inBase = inData.Data)
+            fixed (byte* outBase = outData.Data)
+            {
+                byte* srcPtr = inBase + inData.Pos;
+                byte* dstPtr = outBase + outData.Size;
+
+                int result = SZ_BZip2_v1_0_8_CompressStream(
+                    _ctx, dstPtr, (UIntPtr)outData.AvailableWrite,
+                    srcPtr, (UIntPtr)inData.AvailableRead, BZ_RUN,
+                    out long inSize, out long outSize);
+
+                if (result < 0)
+                    throw new Exception($"BZip2 compression failed with error code {result}");
+
+                if (inSize > 0)
+                    inData.Read((int)inSize);
+                if (outSize > 0)
+                    outData.Write((int)outSize);
+
+                return (int)outSize;
+            }
+        }
+
+        /// <summary>
+        /// Drives one BZ_FLUSH step - a block-boundary flush that leaves the stream open for
+        /// further BZ_RUN input, unlike <see cref="Finish"/>. Returns true once bzip2 signals the
+        /// flush has fully completed (i.e. the stream is ready to accept BZ_RUN input again).
+        /// </summary>
+        /// <param name="outData">The buffer to write flushed data to.</param>
+        /// <param name="bytesWritten">The number of bytes written to <paramref name="outData"/>.</param>
+        /// <returns>True if the flush completed; false if more calls are required.</returns>
+        public bool Flush(CompressionBuffer outData, out int bytesWritten) => step(outData, BZ_FLUSH, BZ_RUN_OK, out bytesWritten);
+
+        /// <summary>
+        /// Drives one BZ_FINISH step, ending the stream. Once called, no further input may be fed.
+        /// Returns true once bzip2 signals BZ_STREAM_END.
+        /// </summary>
+        /// <param name="outData">The buffer to write finalized data to.</param>
+        /// <param name="bytesWritten">The number of bytes written to <paramref name="outData"/>.</param>
+        /// <returns>True if the stream has been finalized; false if more calls are required.</returns>
+        public bool Finish(CompressionBuffer outData, out int bytesWritten) => step(outData, BZ_FINISH, BZ_STREAM_END, out bytesWritten);
+
+        private bool step(CompressionBuffer outData, int action, int doneResult, out int bytesWritten)
+        {
+            outData.Tidy();
+
+            fixed (byte* outBase = outData.Data)
+            {
+                byte* dstPtr = outBase + outData.Size;
+
+                int result = SZ_BZip2_v1_0_8_CompressStream(
+                    _ctx, dstPtr, (UIntPtr)outData.AvailableWrite,
+                    null, (UIntPtr)0, action,
+                    out long inSize, out long outSize);
+
+                if (result < 0)
+                    throw new Exception($"BZip2 {(action == BZ_FINISH ? "finish" : "flush")} failed with error code {result}");
+
+                bytesWritten = (int)outSize;
+                if (bytesWritten > 0)
+                    outData.Write(bytesWritten);
+
+                return result == doneResult;
+            }
+        }
+    }
+}

--- a/src/BZip2/BZip2Stream.cs
+++ b/src/BZip2/BZip2Stream.cs
@@ -1,0 +1,330 @@
+using System;
+using System.IO;
+
+namespace Nanook.GrindCore.BZip2
+{
+    /// <summary>
+    /// Provides a stream implementation for BZip2 compression and decompression.
+    /// Inherits common <see cref="Stream"/> functionality from <see cref="CompressionStream"/>.
+    /// bzip2's bz_stream is deliberately shaped like zlib's z_stream, so this follows
+    /// <c>DeflateStream</c>'s Read/Write/Flush structure rather than LZ4/LZMA's.
+    /// </summary>
+    public class BZip2Stream : CompressionStream
+    {
+        private BZip2Decoder? _decoder;
+        private BZip2Encoder? _encoder;
+        private readonly CompressionBuffer _buffer;
+
+        /// <summary>
+        /// Gets the input buffer size for BZip2 operations.
+        /// </summary>
+        internal override int BufferSizeInput => 0x200000;
+
+        /// <summary>
+        /// Gets the output buffer size for BZip2 operations.
+        /// </summary>
+        internal override int BufferSizeOutput { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BZip2Stream"/> class with the specified stream and options.
+        /// </summary>
+        /// <param name="stream">The underlying stream to read from or write to.</param>
+        /// <param name="options">The compression options to use.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream"/> or <paramref name="options"/> is null.</exception>
+        public BZip2Stream(Stream stream, CompressionOptions options)
+            : base(true, stream, CompressionAlgorithm.BZip2, options)
+        {
+            if (!IsCompress)
+            {
+                this.BufferSizeOutput = 8192;
+                _buffer = new CompressionBuffer(this.BufferSizeOutput);
+                bool small = options?.Dictionary?.SmallDecompress ?? false;
+                _decoder = new BZip2Decoder(small);
+            }
+            else
+            {
+                this.BufferSizeOutput = this.BufferThreshold != 0 ? this.BufferThreshold : this.BufferSizeInput;
+                _buffer = new CompressionBuffer(this.BufferSizeOutput);
+
+                // bzip2's "level" is blockSize100k (1-9); it has no 0/no-compression concept.
+                int level = (int)this.CompressionType;
+                int blockSize100k = level < 1 ? 1 : (level > 9 ? 9 : level);
+                int workFactor = options?.Dictionary?.WorkFactor ?? 0;
+                _encoder = new BZip2Encoder(blockSize100k, workFactor);
+            }
+        }
+
+        /// <summary>
+        /// Reads data from the stream and decompresses it using BZip2.
+        /// Updates the position with the running total of bytes processed from the source stream.
+        /// </summary>
+        /// <param name="data">The buffer to read decompressed data into.</param>
+        /// <param name="cancel">A cancellable task for cooperative cancellation.</param>
+        /// <param name="bytesReadFromStream">The number of bytes read from the underlying stream.</param>
+        /// <param name="length">The maximum number of bytes to read. If 0, the method will fill the buffer if possible.</param>
+        /// <returns>The number of bytes written to the buffer.</returns>
+        /// <exception cref="NotSupportedException">Thrown if the stream is not in decompression mode.</exception>
+        /// <exception cref="InvalidDataException">Thrown if the input stream is truncated.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if cancellation is requested.</exception>
+        internal override int OnRead(CompressionBuffer data, CancellableTask cancel, out int bytesReadFromStream, int length = 0)
+        {
+            if (!this.CanRead)
+                throw new NotSupportedException("Not for Compression mode");
+
+            bytesReadFromStream = 0;
+            int bytesRead;
+            while (true)
+            {
+                cancel.ThrowIfCancellationRequested();
+
+                bytesRead = _decoder!.DecodeData(_buffer, data, length);
+                if (bytesRead != 0 || _decoder.Finished)
+                    break;
+
+                if (_decoder.NeedsInput(_buffer))
+                {
+                    int available = _buffer.AvailableWrite;
+                    int n = BaseRead(_buffer, _buffer.AvailableWrite);
+                    if (n <= 0)
+                    {
+                        if (available != 0 && !_decoder.Finished && _decoder.NonEmptyInput)
+                            throw new InvalidDataException(SR.TruncatedData);
+                        break;
+                    }
+                    bytesReadFromStream += n;
+                }
+
+                if (data.AvailableWrite == 0)
+                    break;
+            }
+
+            return bytesRead;
+        }
+
+        /// <summary>
+        /// Compresses data using BZip2 and writes it to the stream.
+        /// Updates the position with the running total of bytes processed from the source stream.
+        /// </summary>
+        /// <param name="data">The buffer containing data to compress and write.</param>
+        /// <param name="cancel">A cancellable task for cooperative cancellation.</param>
+        /// <param name="bytesWrittenToStream">The number of bytes written to the underlying stream.</param>
+        /// <exception cref="NotSupportedException">Thrown if the stream is not in compression mode.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if cancellation is requested.</exception>
+        internal override void OnWrite(CompressionBuffer data, CancellableTask cancel, out int bytesWrittenToStream)
+        {
+            if (!this.CanWrite)
+                throw new NotSupportedException("Not for Decompression mode");
+
+            bytesWrittenToStream = 0;
+
+            while (data.AvailableRead > 0)
+            {
+                cancel.ThrowIfCancellationRequested();
+
+                int before = data.AvailableRead;
+                int produced = _encoder!.EncodeData(data, _buffer);
+
+                if (_buffer.AvailableRead > 0)
+                {
+                    BaseWrite(_buffer, _buffer.AvailableRead);
+                    bytesWrittenToStream += produced;
+                }
+
+                if (data.AvailableRead == before && produced == 0)
+                    break; // avoid a busy loop if no progress was made (output buffer full)
+            }
+        }
+
+        /// <summary>
+        /// Flushes any remaining compressed data to the stream.
+        /// </summary>
+        /// <param name="data">The buffer containing data to flush.</param>
+        /// <param name="cancel">A cancellable task for cooperative cancellation.</param>
+        /// <param name="bytesWrittenToStream">The number of bytes written to the underlying stream.</param>
+        /// <param name="flush">Indicates if this is a flush operation (BZ_FLUSH: block-boundary flush, stream stays open).</param>
+        /// <param name="complete">Indicates that there is no more data to compress (BZ_FINISH: ends the stream).</param>
+        /// <exception cref="OperationCanceledException">Thrown if cancellation is requested.</exception>
+        internal override void OnFlush(CompressionBuffer data, CancellableTask cancel, out int bytesWrittenToStream, bool flush, bool complete)
+        {
+            bytesWrittenToStream = 0;
+
+            if (IsCompress)
+            {
+                cancel.ThrowIfCancellationRequested();
+
+                OnWrite(data, cancel, out int written);
+                bytesWrittenToStream += written;
+
+                if (flush)
+                {
+                    bool flushDone;
+                    do
+                    {
+                        cancel.ThrowIfCancellationRequested();
+                        flushDone = _encoder!.Flush(_buffer, out int flushedBytes);
+                        if (flushedBytes > 0)
+                        {
+                            BaseWrite(_buffer, flushedBytes);
+                            bytesWrittenToStream += flushedBytes;
+                        }
+                    } while (!flushDone);
+                }
+
+                if (complete)
+                {
+                    bool finished;
+                    do
+                    {
+                        cancel.ThrowIfCancellationRequested();
+                        finished = _encoder!.Finish(_buffer, out int finishedBytes);
+                        if (finishedBytes > 0)
+                        {
+                            BaseWrite(_buffer, finishedBytes);
+                            bytesWrittenToStream += finishedBytes;
+                        }
+                    } while (!finished);
+                }
+            }
+        }
+
+#if !CLASSIC && (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)
+        /// <summary>
+        /// Asynchronously reads data from the stream and decompresses it using BZip2.
+        /// This override provides true async I/O without blocking.
+        /// </summary>
+        internal override async System.Threading.Tasks.ValueTask<(int result, int bytesRead)> OnReadAsync(
+            CompressionBuffer data,
+            System.Threading.CancellationToken cancellationToken,
+            int length = 0)
+        {
+            if (!this.CanRead)
+                throw new NotSupportedException("Not for Compression mode");
+
+            int bytesReadFromStream = 0;
+            int bytesRead;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                bytesRead = _decoder!.DecodeData(_buffer, data, length);
+                if (bytesRead != 0 || _decoder.Finished)
+                    break;
+
+                if (_decoder.NeedsInput(_buffer))
+                {
+                    int available = _buffer.AvailableWrite;
+                    int n = await BaseReadAsync(_buffer, _buffer.AvailableWrite, cancellationToken).ConfigureAwait(false);
+                    if (n <= 0)
+                    {
+                        if (available != 0 && !_decoder.Finished && _decoder.NonEmptyInput)
+                            throw new InvalidDataException(SR.TruncatedData);
+                        break;
+                    }
+                    bytesReadFromStream += n;
+                }
+
+                if (data.AvailableWrite == 0)
+                    break;
+            }
+
+            return (bytesRead, bytesReadFromStream);
+        }
+
+        /// <summary>
+        /// Asynchronously compresses data using BZip2 and writes it to the stream.
+        /// This override provides true async I/O without blocking.
+        /// </summary>
+        internal override async System.Threading.Tasks.ValueTask<int> OnWriteAsync(
+            CompressionBuffer data,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            if (!this.CanWrite)
+                throw new NotSupportedException("Not for Decompression mode");
+
+            int bytesWrittenToStream = 0;
+
+            while (data.AvailableRead > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                int before = data.AvailableRead;
+                int produced = _encoder!.EncodeData(data, _buffer);
+
+                if (_buffer.AvailableRead > 0)
+                {
+                    await BaseWriteAsync(_buffer, _buffer.AvailableRead, cancellationToken).ConfigureAwait(false);
+                    bytesWrittenToStream += produced;
+                }
+
+                if (data.AvailableRead == before && produced == 0)
+                    break;
+            }
+
+            return bytesWrittenToStream;
+        }
+
+        /// <summary>
+        /// Asynchronously flushes any remaining compressed data to the stream.
+        /// This override provides true async I/O without blocking.
+        /// </summary>
+        internal override async System.Threading.Tasks.ValueTask<int> OnFlushAsync(
+            CompressionBuffer data,
+            System.Threading.CancellationToken cancellationToken,
+            bool flush,
+            bool complete)
+        {
+            int bytesWrittenToStream = 0;
+
+            if (IsCompress)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                bytesWrittenToStream += await OnWriteAsync(data, cancellationToken).ConfigureAwait(false);
+
+                if (flush)
+                {
+                    bool flushDone;
+                    do
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        flushDone = _encoder!.Flush(_buffer, out int flushedBytes);
+                        if (flushedBytes > 0)
+                        {
+                            await BaseWriteAsync(_buffer, flushedBytes, cancellationToken).ConfigureAwait(false);
+                            bytesWrittenToStream += flushedBytes;
+                        }
+                    } while (!flushDone);
+                }
+
+                if (complete)
+                {
+                    bool finished;
+                    do
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        finished = _encoder!.Finish(_buffer, out int finishedBytes);
+                        if (finishedBytes > 0)
+                        {
+                            await BaseWriteAsync(_buffer, finishedBytes, cancellationToken).ConfigureAwait(false);
+                            bytesWrittenToStream += finishedBytes;
+                        }
+                    } while (!finished);
+                }
+            }
+
+            return bytesWrittenToStream;
+        }
+#endif
+
+        /// <summary>
+        /// Disposes the <see cref="BZip2Stream"/> and its resources.
+        /// </summary>
+        protected override void OnDispose()
+        {
+            if (IsCompress)
+                try { _encoder?.Dispose(); } catch { }
+            else
+                try { _decoder?.Dispose(); } catch { }
+        }
+    }
+}

--- a/src/CompressionAlgorithm.cs
+++ b/src/CompressionAlgorithm.cs
@@ -17,6 +17,7 @@
         Lzma2,
         FastLzma2,
         Lz4,
-        ZStd
+        ZStd,
+        BZip2
     }
 }

--- a/src/CompressionBlockFactory.cs
+++ b/src/CompressionBlockFactory.cs
@@ -1,4 +1,5 @@
 using Nanook.GrindCore.Brotli;
+using Nanook.GrindCore.BZip2;
 using Nanook.GrindCore.Copy;
 using Nanook.GrindCore.DeflateZLib;
 using Nanook.GrindCore.FastLzma2;
@@ -19,6 +20,7 @@ namespace Nanook.GrindCore
         {
             { CompressionAlgorithm.Copy, (options) => new CopyBlock(options) },
             { CompressionAlgorithm.Brotli, (options) => new BrotliBlock(options) },
+            { CompressionAlgorithm.BZip2, (options) => new BZip2Block(options) },
             { CompressionAlgorithm.Deflate, (options) => new DeflateBlock(options) },
             { CompressionAlgorithm.DeflateNg, (options) => new DeflateBlock(options) },
             { CompressionAlgorithm.FastLzma2, (options) => new FastLzma2Block(options) },

--- a/src/CompressionDefaults.cs
+++ b/src/CompressionDefaults.cs
@@ -77,6 +77,14 @@ namespace Nanook.GrindCore
                     this.LevelSmallestSize = CompressionType.Level22;
                     this.Version = version ?? CompressionVersion.ZStdLatest();
                     break;
+                case CompressionAlgorithm.BZip2:
+                    // bzip2's blockSize100k (1-9) has little speed impact compared to LZMA's levels;
+                    // the bzip2 CLI itself defaults to -9 (largest blocks, best ratio) unless the
+                    // caller is memory-constrained, so both defaults point at the maximum.
+                    this.LevelOptimal = CompressionType.Level9;
+                    this.LevelSmallestSize = CompressionType.Level9;
+                    this.Version = version ?? CompressionVersion.BZip2Latest();
+                    break;
                 default:
                     break;
             }

--- a/src/CompressionOptions.cs
+++ b/src/CompressionOptions.cs
@@ -464,7 +464,12 @@ namespace Nanook.GrindCore
         /// Gets or sets the window size as a power of 2 (log2 value) for algorithms that use logarithmic sizing.
         /// Alternative to DictionarySize for algorithms that prefer logarithmic parameters.
         /// <para><strong>Algorithms:</strong></para>
-        /// <para>• <strong>ZStd:</strong> WindowLog range: 10-31. Default: 23 (8MB). Dictionary size = 2^WindowBits</para>
+        /// <para>• <strong>ZStd:</strong> WindowLog range: 10-31. Unset (null) uses zstd's own implicit,
+        /// level-based window sizing for both block sizing and (when a content dictionary is supplied via
+        /// <see cref="CompressionOptions.InitProperties"/>) the dictionary's CDict - which caps out at 8MB for
+        /// any dictionary larger than 256KB at level 19 and never grows further, no matter how much bigger the
+        /// dictionary gets. Set this explicitly to override that cap when using a dictionary larger than ~8MB;
+        /// otherwise leave unset. Dictionary/block size = 2^WindowBits</para>
         /// <para>• <strong>Brotli:</strong> Window bits range: 10-24. Default: 22 (4MB). Larger = better compression</para>
         /// <para>• <strong>ZLib/Deflate/GZip:</strong> Range: 8-15 (256B-32KB), or negative (-8 to -15) for raw deflate without headers</para>
         /// <para><strong>Impact:</strong> Higher values increase memory usage but improve compression for large files.</para>

--- a/src/CompressionOptions.cs
+++ b/src/CompressionOptions.cs
@@ -662,5 +662,31 @@ namespace Nanook.GrindCore
         /// <para>Level 11 provides maximum compression but slowest speed.</para>
         /// </summary>
         public int? Quality { get; set; }
+
+        /// <summary>
+        /// Gets or sets bzip2's compression work factor.
+        /// Controls when bzip2 falls back from its normal sorting algorithm to a slower, more
+        /// conservative one that avoids worst-case (near-quadratic) behavior on pathological or
+        /// highly repetitive input.
+        /// <para><strong>Algorithms:</strong></para>
+        /// <para>• <strong>BZip2:</strong> Range: 0-250. 0 selects bzip2's own default (30).</para>
+        /// <para><strong>Impact:</strong> Has no effect on decompression and (in nearly all practical
+        /// cases) no effect on the compressed output size - it only affects how much CPU time
+        /// compression can take on adversarial/degenerate input. Lower values trade that safety
+        /// margin for a small amount of speed on ordinary data; there's rarely a reason to change
+        /// this from the default.</para>
+        /// </summary>
+        public int? WorkFactor { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether bzip2 decompression uses its reduced-memory algorithm.
+        /// <para><strong>Algorithms:</strong></para>
+        /// <para>• <strong>BZip2:</strong> false/unset (default) = normal algorithm. true = ~2.5x less
+        /// memory, some speed cost. Has no effect on compression - decompression-only.</para>
+        /// <para><strong>Impact:</strong> Useful primarily on memory-constrained targets; the memory
+        /// saved scales with the BlockSize/level used at compression time, not with this setting
+        /// itself.</para>
+        /// </summary>
+        public bool? SmallDecompress { get; set; }
     }
 }

--- a/src/CompressionStreamFactory.cs
+++ b/src/CompressionStreamFactory.cs
@@ -1,4 +1,5 @@
 using Nanook.GrindCore.Brotli;
+using Nanook.GrindCore.BZip2;
 using Nanook.GrindCore.Copy;
 using Nanook.GrindCore.DeflateZLib;
 using Nanook.GrindCore.FastLzma2;
@@ -22,6 +23,7 @@ namespace Nanook.GrindCore
         {
             { CompressionAlgorithm.Copy, (stream, options) => new CopyStream(stream, options) },
             { CompressionAlgorithm.Brotli, (stream, options) => new BrotliStream(stream, options) },
+            { CompressionAlgorithm.BZip2, (stream, options) => new BZip2Stream(stream, options) },
             { CompressionAlgorithm.Deflate, (stream, options) => new DeflateStream(stream, options) },
             { CompressionAlgorithm.DeflateNg, (stream, options) => new DeflateStream(stream, options) },
             { CompressionAlgorithm.FastLzma2, (stream, options) => new FastLzma2Stream(stream, options) },

--- a/src/CompressionType.cs
+++ b/src/CompressionType.cs
@@ -64,6 +64,7 @@ namespace Nanook.GrindCore
         MaxFastLzma2 = Level10,
         MaxBrotli = Level11,
         MaxZStd = Level22,
+        MaxBZip2 = Level9,
     }
 
 }

--- a/src/CompressionVersion.cs
+++ b/src/CompressionVersion.cs
@@ -85,6 +85,15 @@ namespace Nanook.GrindCore
     }
 
     /// <summary>
+    /// Specifies supported versions for the BZip2 algorithm.
+    /// </summary>
+    public enum BZip2Version
+    {
+        v1_0_8 = 1,
+        Latest = v1_0_8
+    }
+
+    /// <summary>
     /// Represents a version for a specific compression algorithm.
     /// </summary>
     public class CompressionVersion
@@ -103,6 +112,7 @@ namespace Nanook.GrindCore
         public const string LZ4_v1_10_0 = "1.10.0";
         public const string ZSTD_v1_5_2 = "1.5.2";
         public const string ZSTD_v1_5_7 = "1.5.7";
+        public const string BZIP2_v1_0_8 = "1.0.8";
 
         /// <summary>
         /// Converts an enum name to a version string (e.g., v1_2_3 to 1.2.3).
@@ -234,6 +244,17 @@ namespace Nanook.GrindCore
         public static CompressionVersion ZStd(ZStdVersion version) => create(CompressionAlgorithm.ZStd, enumStringToVersionString(Enum.GetName(typeof(ZStdVersion), (int)version)!));
 
         /// <summary>
+        /// Gets the latest version for the BZip2 algorithm.
+        /// </summary>
+        public static CompressionVersion BZip2Latest() => BZip2(BZip2Version.Latest);
+
+        /// <summary>
+        /// Gets a specific version for the BZip2 algorithm.
+        /// </summary>
+        /// <param name="version">The version enum value.</param>
+        public static CompressionVersion BZip2(BZip2Version version) => create(CompressionAlgorithm.BZip2, enumStringToVersionString(Enum.GetName(typeof(BZip2Version), (int)version)!));
+
+        /// <summary>
         /// Private constructor to prevent direct instantiation.
         /// </summary>
         private CompressionVersion()
@@ -305,6 +326,13 @@ namespace Nanook.GrindCore
                     if (string.IsNullOrEmpty(version) || version == BROTLI_v1_1_0)
                     {
                         result.Version = BROTLI_v1_1_0;
+                        result.Index = 0;
+                    }
+                    break;
+                case CompressionAlgorithm.BZip2:
+                    if (string.IsNullOrEmpty(version) || version == BZIP2_v1_0_8)
+                    {
+                        result.Version = BZIP2_v1_0_8;
                         result.Index = 0;
                     }
                     break;

--- a/src/GrindCore.net.csproj
+++ b/src/GrindCore.net.csproj
@@ -7,7 +7,7 @@
 		<AssemblyName>Nanook.GrindCore</AssemblyName>
 		<LangVersion>latest</LangVersion>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-		<Version>0.8.0</Version>
+		<Version>0.8.2</Version>
 		<RootNamespace>Nanook.GrindCore</RootNamespace>
 		<Configurations>Debug;Release;ReleaseTest</Configurations>
 		<RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-x86;linux-arm64;linux-arm;osx-x64;osx-arm64</RuntimeIdentifiers>
@@ -16,7 +16,7 @@
 		<Authors>Nanook</Authors>
 		<Description>Native Compression and Hashing library built the System.IO.Compression way.</Description>
 		<PackageTags>
-			ZStd;LZ4;LZMA;LZMA2;GZip;ZLib;ZLib-NG;Deflate;Brotli;Fast-LZMA2;
+			ZStd;LZ4;LZMA;LZMA2;GZip;ZLib;ZLib-NG;Deflate;Brotli;Fast-LZMA2;BZip2;
 			Blake3;Blake2sp;MD5;MD4;MD2;SHA1;SHA2;SHA256;SHA384;SHA512;SHA3;SHA3-224;SHA3-256;SHA3-384;SHA3-512;
 			XXHash;XXH32;XXH64;Multi-Framework;Multi-Platform;Cross-Platform;DotNet;Library;AOT;Native;Compression;
 			Fast;High-Performance;Efficient;ZStandard;ZStandard Random Access;ZStandard Seekable;Hashing;Stream;Block

--- a/src/Interop/Interop.BZip2.cs
+++ b/src/Interop/Interop.BZip2.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Runtime.InteropServices;
+using static Nanook.GrindCore.Interop;
+
+namespace Nanook.GrindCore
+{
+    internal static partial class Interop
+    {
+        /// <summary>
+        /// Mirrors the native bz_stream layout embedded (by value) inside
+        /// SZ_BZip2_v1_0_8_CompressionContext. Used ONLY via <c>Marshal.SizeOf</c> to size the fixed
+        /// unmanaged allocation BZip2Encoder makes for the real context - never instantiated or
+        /// passed by value/ref itself. libbzip2 stores the exact bz_stream* address passed to
+        /// BZ2_bzCompressInit and rejects any later call whose pointer doesn't match byte-for-byte
+        /// (bzlib.c: `if (s->strm != strm) return BZ_PARAM_ERROR`), so the context must live at a
+        /// single fixed address for its whole lifetime - a managed struct field can't guarantee
+        /// that across separate P/Invoke calls under a compacting GC, hence unmanaged allocation
+        /// (see BZip2Encoder/BZip2Decoder) rather than the "PAL owns a managed struct by value"
+        /// style used elsewhere (e.g. Interop.ZStream for pal_zlib_v1_3_1's PAL_ZStream, which zlib
+        /// itself never validates the address of).
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SZ_BZip2_v1_0_8_CompressionContext
+        {
+            internal IntPtr nextIn;
+            internal uint availIn;
+            internal uint totalInLo32;
+            internal uint totalInHi32;
+            internal IntPtr nextOut;
+            internal uint availOut;
+            internal uint totalOutLo32;
+            internal uint totalOutHi32;
+            internal IntPtr state;
+            internal IntPtr bzalloc;
+            internal IntPtr bzfree;
+            internal IntPtr opaque;
+        }
+
+        /// <summary>
+        /// Mirrors the native bz_stream layout embedded (by value) inside
+        /// SZ_BZip2_v1_0_8_DecompressionContext, used only for sizing. See
+        /// <see cref="SZ_BZip2_v1_0_8_CompressionContext"/>.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SZ_BZip2_v1_0_8_DecompressionContext
+        {
+            internal IntPtr nextIn;
+            internal uint availIn;
+            internal uint totalInLo32;
+            internal uint totalInHi32;
+            internal IntPtr nextOut;
+            internal uint availOut;
+            internal uint totalOutLo32;
+            internal uint totalOutHi32;
+            internal IntPtr state;
+            internal IntPtr bzalloc;
+            internal IntPtr bzfree;
+            internal IntPtr opaque;
+        }
+
+        internal static unsafe partial class BZip2
+        {
+            // BZip2 (libbzip2 1.0.8) result codes - see external/bzip2/bzip2/bzlib.h
+            public const int BZ_OK = 0;
+            public const int BZ_RUN_OK = 1;
+            public const int BZ_FLUSH_OK = 2;
+            public const int BZ_FINISH_OK = 3;
+            public const int BZ_STREAM_END = 4;
+            public const int BZ_SEQUENCE_ERROR = -1;
+            public const int BZ_PARAM_ERROR = -2;
+            public const int BZ_MEM_ERROR = -3;
+            public const int BZ_DATA_ERROR = -4;
+            public const int BZ_DATA_ERROR_MAGIC = -5;
+            public const int BZ_IO_ERROR = -6;
+            public const int BZ_UNEXPECTED_EOF = -7;
+            public const int BZ_OUTBUFF_FULL = -8;
+            public const int BZ_CONFIG_ERROR = -9;
+
+            // BZ2_bzCompress action codes
+            public const int BZ_RUN = 0;
+            public const int BZ_FLUSH = 1;
+            public const int BZ_FINISH = 2;
+
+            /* ===== Streaming Compression =====
+             * ctx is a pointer to a fixed (never-moving) block of unmanaged memory sized to hold
+             * SZ_BZip2_v1_0_8_CompressionContext, allocated and freed by the caller (BZip2Encoder) -
+             * NOT a `ref` onto a managed struct field. libbzip2's BZ2_bzCompress/BZ2_bzCompressEnd
+             * store the bz_stream* pointer passed to BZ2_bzCompressInit and reject every later call
+             * whose strm pointer doesn't match it byte-for-byte (bzlib.c: `if (s->strm != strm)
+             * return BZ_PARAM_ERROR`) - so the context's address must never change across the
+             * Create/Compress/Free call sequence, which a compacting-GC-managed struct field cannot
+             * guarantee between separate P/Invoke calls. */
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_CreateCompressionContext(
+                IntPtr ctx, int blockSize100k, int workFactor);
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_CompressStream(
+                IntPtr ctx,
+                byte* dst, UIntPtr dstCapacity,
+                byte* src, UIntPtr srcSize,
+                int action,
+                out long inSize, out long outSize);
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_FreeCompressionContext(IntPtr ctx);
+
+            /* ===== Streaming Decompression ===== (same fixed-address requirement as above) */
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_CreateDecompressionContext(
+                IntPtr ctx, int small);
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_DecompressStream(
+                IntPtr ctx,
+                byte* dst, UIntPtr dstCapacity,
+                byte* src, UIntPtr srcSize,
+                out long inSize, out long outSize);
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_FreeDecompressionContext(IntPtr ctx);
+
+            /* ===== Block Compression & Decompression (one-shot, no persistent context) ===== */
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_CompressBlock(
+                byte* dst, ref UIntPtr dstCapacity,
+                byte* src, UIntPtr srcSize,
+                int blockSize100k, int workFactor);
+
+            [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int SZ_BZip2_v1_0_8_DecompressBlock(
+                byte* dst, ref UIntPtr dstCapacity,
+                byte* src, UIntPtr srcSize,
+                int small);
+        }
+    }
+}

--- a/src/Interop/Interop.ZStd.cs
+++ b/src/Interop/Interop.ZStd.cs
@@ -118,7 +118,7 @@ namespace Nanook.GrindCore
 
             /* ===== Dictionary Handling ===== */
             [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
-            public static extern int SZ_ZStd_v1_5_7_CreateCompressionDict(SZ_ZStd_v1_5_7_CompressionDict* dict, IntPtr dictBuffer, UIntPtr dictSize, int compressionLevel);
+            public static extern int SZ_ZStd_v1_5_7_CreateCompressionDict(SZ_ZStd_v1_5_7_CompressionDict* dict, IntPtr dictBuffer, UIntPtr dictSize, int compressionLevel, int windowLog);
 
             [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
             public static extern int SZ_ZStd_v1_5_7_CreateDecompressionDict(SZ_ZStd_v1_5_7_DecompressionDict* dict, IntPtr dictBuffer, UIntPtr dictSize);
@@ -359,7 +359,7 @@ namespace Nanook.GrindCore
 
             /* ===== Dictionary Handling ===== */
             [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
-            public static extern int SZ_ZStd_v1_5_2_CreateCompressionDict(SZ_ZStd_v1_5_2_CompressionDict* dict, IntPtr dictBuffer, UIntPtr dictSize, int compressionLevel);
+            public static extern int SZ_ZStd_v1_5_2_CreateCompressionDict(SZ_ZStd_v1_5_2_CompressionDict* dict, IntPtr dictBuffer, UIntPtr dictSize, int compressionLevel, int windowLog);
 
             [DllImport(Libraries.GrindCoreLib, CallingConvention = CallingConvention.Cdecl)]
             public static extern int SZ_ZStd_v1_5_2_CreateDecompressionDict(SZ_ZStd_v1_5_2_DecompressionDict* dict, IntPtr dictBuffer, UIntPtr dictSize);

--- a/src/Nanook.GrindCore.net.xml
+++ b/src/Nanook.GrindCore.net.xml
@@ -610,6 +610,251 @@
             Periodically removes stale buffers from the pool that have not been used for a threshold period.
             </summary>
         </member>
+        <member name="T:Nanook.GrindCore.BZip2.BZip2Block">
+            <summary>
+            Provides a block-based implementation of the BZip2 compression algorithm.
+            </summary>
+        </member>
+        <member name="P:Nanook.GrindCore.BZip2.BZip2Block.RequiredCompressOutputSize">
+            <summary>
+            Gets the required output buffer size for compression, as determined by bzip2's own
+            documented worst-case bound (source size + 1% + 600 bytes; see BZ2_bzBuffToBuffCompress
+            in bzlib.h).
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Block.#ctor(Nanook.GrindCore.CompressionOptions)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Nanook.GrindCore.BZip2.BZip2Block"/> class with the specified compression options.
+            </summary>
+            <param name="options">The compression options to use.</param>
+            <exception cref="T:System.ArgumentNullException">Thrown if <paramref name="options"/> or <c>options.BlockSize</c> is null.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Block.OnCompress(Nanook.GrindCore.DataBlock,Nanook.GrindCore.DataBlock,System.Int32@)">
+            <summary>
+            Compresses the source data block into the destination data block using BZip2.
+            </summary>
+            <param name="srcData">The source data block to compress.</param>
+            <param name="dstData">The destination data block to write compressed data to.</param>
+            <param name="dstCount">On input, the maximum bytes available; on output, the actual bytes written.</param>
+            <returns>The compression result code.</returns>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Block.OnDecompress(Nanook.GrindCore.DataBlock,Nanook.GrindCore.DataBlock,System.Int32@)">
+            <summary>
+            Decompresses the source data block into the destination data block using BZip2.
+            </summary>
+            <param name="srcData">The source data block to decompress.</param>
+            <param name="dstData">The destination data block to write decompressed data to.</param>
+            <param name="dstCount">On input, the maximum bytes available; on output, the actual bytes written.</param>
+            <returns>The compression result code.</returns>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Block.OnDispose">
+            <summary>
+            Releases any resources used by the <see cref="T:Nanook.GrindCore.BZip2.BZip2Block"/>. No resources to release for BZip2 blocks.
+            </summary>
+        </member>
+        <member name="T:Nanook.GrindCore.BZip2.BZip2Decoder">
+            <summary>
+            Provides a wrapper around the BZip2 streaming decompression API, supporting transparent
+            decompression of concatenated ("multi-stream") .bz2 data - bzip2 has documented this
+            concatenation convention since 0.9.0 (the same way multiple gzip members can be
+            concatenated and decompress as one logical stream; see <c>DeflateDecoder</c>'s
+            <c>resetStreamForLeftoverInput</c> for the equivalent gzip-side handling).
+            </summary>
+        </member>
+        <member name="P:Nanook.GrindCore.BZip2.BZip2Decoder.Finished">
+            <summary>
+            Returns true if the end of the (possibly multi-stream) input has been reached.
+            </summary>
+        </member>
+        <member name="P:Nanook.GrindCore.BZip2.BZip2Decoder.NonEmptyInput">
+            <summary>
+            Returns true if any non-empty input has ever been provided.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Decoder.#ctor(System.Boolean)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Nanook.GrindCore.BZip2.BZip2Decoder"/> class.
+            </summary>
+            <param name="smallDecompress">
+            When true, selects bzip2's reduced-memory decompression algorithm (~2.5x less memory, some speed cost).
+            </param>
+            <exception cref="T:System.Exception">Thrown if the native decompression context cannot be created.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Decoder.Finalize">
+            <summary>
+            Finalizer to ensure resources are released.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Decoder.Dispose">
+            <summary>
+            Releases all resources used by the <see cref="T:Nanook.GrindCore.BZip2.BZip2Decoder"/>.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Decoder.NeedsInput(Nanook.GrindCore.CompressionBuffer)">
+            <summary>
+            Returns true if there is no available input to feed the decoder.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Decoder.DecodeData(Nanook.GrindCore.CompressionBuffer,Nanook.GrindCore.CompressionBuffer,System.Int32)">
+            <summary>
+            Decompresses available input from <paramref name="inData"/> into <paramref name="outData"/>.
+            If bzip2 reports the end of a stream and further input immediately looks like another
+            bzip2 header, the decoder transparently reinitializes and continues (multi-stream
+            concatenation); otherwise <see cref="P:Nanook.GrindCore.BZip2.BZip2Decoder.Finished"/> becomes true.
+            </summary>
+            <param name="inData">The input buffer containing compressed data.</param>
+            <param name="outData">The output buffer to write decompressed data to.</param>
+            <param name="length">The maximum number of bytes to write. If 0, fills the available output space.</param>
+            <returns>The number of bytes written to <paramref name="outData"/>.</returns>
+            <exception cref="T:System.IO.InvalidDataException">Thrown if the input data is corrupted or invalid.</exception>
+        </member>
+        <member name="T:Nanook.GrindCore.BZip2.BZip2Encoder">
+            <summary>
+            Provides a wrapper around the BZip2 streaming compression API. bzip2's bz_stream is
+            deliberately shaped like zlib's z_stream, so this mirrors <c>DeflateEncoder</c>'s shape
+            (one call drives one native step; the caller loops and drains output between calls) rather
+            than LZ4/LZMA's multi-call-per-invocation style.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.#ctor(System.Int32,System.Int32)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Nanook.GrindCore.BZip2.BZip2Encoder"/> class with the specified
+            block size and work factor.
+            </summary>
+            <param name="blockSize100k">Block size, 1-9 (900k*n block size).</param>
+            <param name="workFactor">Work factor, 0-250 (0 = bzip2's own default).</param>
+            <exception cref="T:System.Exception">Thrown if the native compression context cannot be created.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.Finalize">
+            <summary>
+            Finalizer to ensure resources are released.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.Dispose">
+            <summary>
+            Releases all resources used by the <see cref="T:Nanook.GrindCore.BZip2.BZip2Encoder"/>.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.NeedsInput(Nanook.GrindCore.CompressionBuffer)">
+            <summary>
+            Returns true if there is no available input to feed the encoder.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.EncodeData(Nanook.GrindCore.CompressionBuffer,Nanook.GrindCore.CompressionBuffer)">
+            <summary>
+            Feeds available input to the encoder (BZ_RUN) and writes any produced output to outData.
+            A single native call may not consume/produce everything available; callers loop while
+            input and output space both remain.
+            </summary>
+            <param name="inData">The input buffer containing data to compress.</param>
+            <param name="outData">The output buffer to write compressed data to.</param>
+            <returns>The number of bytes written to <paramref name="outData"/>.</returns>
+            <exception cref="T:System.Exception">Thrown if the native compress step reports an error.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.Flush(Nanook.GrindCore.CompressionBuffer,System.Int32@)">
+            <summary>
+            Drives one BZ_FLUSH step - a block-boundary flush that leaves the stream open for
+            further BZ_RUN input, unlike <see cref="M:Nanook.GrindCore.BZip2.BZip2Encoder.Finish(Nanook.GrindCore.CompressionBuffer,System.Int32@)"/>. Returns true once bzip2 signals the
+            flush has fully completed (i.e. the stream is ready to accept BZ_RUN input again).
+            </summary>
+            <param name="outData">The buffer to write flushed data to.</param>
+            <param name="bytesWritten">The number of bytes written to <paramref name="outData"/>.</param>
+            <returns>True if the flush completed; false if more calls are required.</returns>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Encoder.Finish(Nanook.GrindCore.CompressionBuffer,System.Int32@)">
+            <summary>
+            Drives one BZ_FINISH step, ending the stream. Once called, no further input may be fed.
+            Returns true once bzip2 signals BZ_STREAM_END.
+            </summary>
+            <param name="outData">The buffer to write finalized data to.</param>
+            <param name="bytesWritten">The number of bytes written to <paramref name="outData"/>.</param>
+            <returns>True if the stream has been finalized; false if more calls are required.</returns>
+        </member>
+        <member name="T:Nanook.GrindCore.BZip2.BZip2Stream">
+            <summary>
+            Provides a stream implementation for BZip2 compression and decompression.
+            Inherits common <see cref="T:System.IO.Stream"/> functionality from <see cref="T:Nanook.GrindCore.CompressionStream"/>.
+            bzip2's bz_stream is deliberately shaped like zlib's z_stream, so this follows
+            <c>DeflateStream</c>'s Read/Write/Flush structure rather than LZ4/LZMA's.
+            </summary>
+        </member>
+        <member name="P:Nanook.GrindCore.BZip2.BZip2Stream.BufferSizeInput">
+            <summary>
+            Gets the input buffer size for BZip2 operations.
+            </summary>
+        </member>
+        <member name="P:Nanook.GrindCore.BZip2.BZip2Stream.BufferSizeOutput">
+            <summary>
+            Gets the output buffer size for BZip2 operations.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.#ctor(System.IO.Stream,Nanook.GrindCore.CompressionOptions)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Nanook.GrindCore.BZip2.BZip2Stream"/> class with the specified stream and options.
+            </summary>
+            <param name="stream">The underlying stream to read from or write to.</param>
+            <param name="options">The compression options to use.</param>
+            <exception cref="T:System.ArgumentNullException">Thrown if <paramref name="stream"/> or <paramref name="options"/> is null.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnRead(Nanook.GrindCore.CompressionBuffer,Nanook.GrindCore.CancellableTask,System.Int32@,System.Int32)">
+            <summary>
+            Reads data from the stream and decompresses it using BZip2.
+            Updates the position with the running total of bytes processed from the source stream.
+            </summary>
+            <param name="data">The buffer to read decompressed data into.</param>
+            <param name="cancel">A cancellable task for cooperative cancellation.</param>
+            <param name="bytesReadFromStream">The number of bytes read from the underlying stream.</param>
+            <param name="length">The maximum number of bytes to read. If 0, the method will fill the buffer if possible.</param>
+            <returns>The number of bytes written to the buffer.</returns>
+            <exception cref="T:System.NotSupportedException">Thrown if the stream is not in decompression mode.</exception>
+            <exception cref="T:System.IO.InvalidDataException">Thrown if the input stream is truncated.</exception>
+            <exception cref="T:System.OperationCanceledException">Thrown if cancellation is requested.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnWrite(Nanook.GrindCore.CompressionBuffer,Nanook.GrindCore.CancellableTask,System.Int32@)">
+            <summary>
+            Compresses data using BZip2 and writes it to the stream.
+            Updates the position with the running total of bytes processed from the source stream.
+            </summary>
+            <param name="data">The buffer containing data to compress and write.</param>
+            <param name="cancel">A cancellable task for cooperative cancellation.</param>
+            <param name="bytesWrittenToStream">The number of bytes written to the underlying stream.</param>
+            <exception cref="T:System.NotSupportedException">Thrown if the stream is not in compression mode.</exception>
+            <exception cref="T:System.OperationCanceledException">Thrown if cancellation is requested.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnFlush(Nanook.GrindCore.CompressionBuffer,Nanook.GrindCore.CancellableTask,System.Int32@,System.Boolean,System.Boolean)">
+            <summary>
+            Flushes any remaining compressed data to the stream.
+            </summary>
+            <param name="data">The buffer containing data to flush.</param>
+            <param name="cancel">A cancellable task for cooperative cancellation.</param>
+            <param name="bytesWrittenToStream">The number of bytes written to the underlying stream.</param>
+            <param name="flush">Indicates if this is a flush operation (BZ_FLUSH: block-boundary flush, stream stays open).</param>
+            <param name="complete">Indicates that there is no more data to compress (BZ_FINISH: ends the stream).</param>
+            <exception cref="T:System.OperationCanceledException">Thrown if cancellation is requested.</exception>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnReadAsync(Nanook.GrindCore.CompressionBuffer,System.Threading.CancellationToken,System.Int32)">
+            <summary>
+            Asynchronously reads data from the stream and decompresses it using BZip2.
+            This override provides true async I/O without blocking.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnWriteAsync(Nanook.GrindCore.CompressionBuffer,System.Threading.CancellationToken)">
+            <summary>
+            Asynchronously compresses data using BZip2 and writes it to the stream.
+            This override provides true async I/O without blocking.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnFlushAsync(Nanook.GrindCore.CompressionBuffer,System.Threading.CancellationToken,System.Boolean,System.Boolean)">
+            <summary>
+            Asynchronously flushes any remaining compressed data to the stream.
+            This override provides true async I/O without blocking.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.BZip2.BZip2Stream.OnDispose">
+            <summary>
+            Disposes the <see cref="T:Nanook.GrindCore.BZip2.BZip2Stream"/> and its resources.
+            </summary>
+        </member>
         <member name="T:Nanook.GrindCore.CancellableTask">
             <summary>
             Represents a cancellable task using a <see cref="T:System.Threading.CancellationToken"/> for supported frameworks.
@@ -1357,6 +1602,32 @@
             <para>Level 11 provides maximum compression but slowest speed.</para>
             </summary>
         </member>
+        <member name="P:Nanook.GrindCore.CompressionDictionaryOptions.WorkFactor">
+            <summary>
+            Gets or sets bzip2's compression work factor.
+            Controls when bzip2 falls back from its normal sorting algorithm to a slower, more
+            conservative one that avoids worst-case (near-quadratic) behavior on pathological or
+            highly repetitive input.
+            <para><strong>Algorithms:</strong></para>
+            <para>• <strong>BZip2:</strong> Range: 0-250. 0 selects bzip2's own default (30).</para>
+            <para><strong>Impact:</strong> Has no effect on decompression and (in nearly all practical
+            cases) no effect on the compressed output size - it only affects how much CPU time
+            compression can take on adversarial/degenerate input. Lower values trade that safety
+            margin for a small amount of speed on ordinary data; there's rarely a reason to change
+            this from the default.</para>
+            </summary>
+        </member>
+        <member name="P:Nanook.GrindCore.CompressionDictionaryOptions.SmallDecompress">
+            <summary>
+            Gets or sets whether bzip2 decompression uses its reduced-memory algorithm.
+            <para><strong>Algorithms:</strong></para>
+            <para>• <strong>BZip2:</strong> false/unset (default) = normal algorithm. true = ~2.5x less
+            memory, some speed cost. Has no effect on compression - decompression-only.</para>
+            <para><strong>Impact:</strong> Useful primarily on memory-constrained targets; the memory
+            saved scales with the BlockSize/level used at compression time, not with this setting
+            itself.</para>
+            </summary>
+        </member>
         <member name="T:Nanook.GrindCore.CompressionResultCode">
             <summary>
             Defines the result codes for compression and decompression operations.
@@ -1853,6 +2124,11 @@
             Specifies supported versions for the ZStd algorithm.
             </summary>
         </member>
+        <member name="T:Nanook.GrindCore.BZip2Version">
+            <summary>
+            Specifies supported versions for the BZip2 algorithm.
+            </summary>
+        </member>
         <member name="T:Nanook.GrindCore.CompressionVersion">
             <summary>
             Represents a version for a specific compression algorithm.
@@ -1983,6 +2259,17 @@
         <member name="M:Nanook.GrindCore.CompressionVersion.ZStd(Nanook.GrindCore.ZStdVersion)">
             <summary>
             Gets a specific version for the ZStd algorithm.
+            </summary>
+            <param name="version">The version enum value.</param>
+        </member>
+        <member name="M:Nanook.GrindCore.CompressionVersion.BZip2Latest">
+            <summary>
+            Gets the latest version for the BZip2 algorithm.
+            </summary>
+        </member>
+        <member name="M:Nanook.GrindCore.CompressionVersion.BZip2(Nanook.GrindCore.BZip2Version)">
+            <summary>
+            Gets a specific version for the BZip2 algorithm.
             </summary>
             <param name="version">The version enum value.</param>
         </member>
@@ -3679,6 +3966,28 @@
         <member name="T:Nanook.GrindCore.HashType">
             <summary>
             Specifies supported hash algorithms for integrity or fingerprinting.
+            </summary>
+        </member>
+        <member name="T:Nanook.GrindCore.Interop.SZ_BZip2_v1_0_8_CompressionContext">
+            <summary>
+            Mirrors the native bz_stream layout embedded (by value) inside
+            SZ_BZip2_v1_0_8_CompressionContext. Used ONLY via <c>Marshal.SizeOf</c> to size the fixed
+            unmanaged allocation BZip2Encoder makes for the real context - never instantiated or
+            passed by value/ref itself. libbzip2 stores the exact bz_stream* address passed to
+            BZ2_bzCompressInit and rejects any later call whose pointer doesn't match byte-for-byte
+            (bzlib.c: `if (s->strm != strm) return BZ_PARAM_ERROR`), so the context must live at a
+            single fixed address for its whole lifetime - a managed struct field can't guarantee
+            that across separate P/Invoke calls under a compacting GC, hence unmanaged allocation
+            (see BZip2Encoder/BZip2Decoder) rather than the "PAL owns a managed struct by value"
+            style used elsewhere (e.g. Interop.ZStream for pal_zlib_v1_3_1's PAL_ZStream, which zlib
+            itself never validates the address of).
+            </summary>
+        </member>
+        <member name="T:Nanook.GrindCore.Interop.SZ_BZip2_v1_0_8_DecompressionContext">
+            <summary>
+            Mirrors the native bz_stream layout embedded (by value) inside
+            SZ_BZip2_v1_0_8_DecompressionContext, used only for sizing. See
+            <see cref="T:Nanook.GrindCore.Interop.SZ_BZip2_v1_0_8_CompressionContext"/>.
             </summary>
         </member>
         <member name="F:Nanook.GrindCore.Interop.FL2CompressionParameters.DictionarySize">

--- a/src/Nanook.GrindCore.net.xml
+++ b/src/Nanook.GrindCore.net.xml
@@ -1165,7 +1165,12 @@
             Gets or sets the window size as a power of 2 (log2 value) for algorithms that use logarithmic sizing.
             Alternative to DictionarySize for algorithms that prefer logarithmic parameters.
             <para><strong>Algorithms:</strong></para>
-            <para>• <strong>ZStd:</strong> WindowLog range: 10-31. Default: 23 (8MB). Dictionary size = 2^WindowBits</para>
+            <para>• <strong>ZStd:</strong> WindowLog range: 10-31. Unset (null) uses zstd's own implicit,
+            level-based window sizing for both block sizing and (when a content dictionary is supplied via
+            <see cref="P:Nanook.GrindCore.CompressionOptions.InitProperties"/>) the dictionary's CDict - which caps out at 8MB for
+            any dictionary larger than 256KB at level 19 and never grows further, no matter how much bigger the
+            dictionary gets. Set this explicitly to override that cap when using a dictionary larger than ~8MB;
+            otherwise leave unset. Dictionary/block size = 2^WindowBits</para>
             <para>• <strong>Brotli:</strong> Window bits range: 10-24. Default: 22 (4MB). Larger = better compression</para>
             <para>• <strong>ZLib/Deflate/GZip:</strong> Range: 8-15 (256B-32KB), or negative (-8 to -15) for raw deflate without headers</para>
             <para><strong>Impact:</strong> Higher values increase memory usage but improve compression for large files.</para>
@@ -6399,7 +6404,7 @@
             Gets the recommended output buffer size for ZStd compression.
             </summary>
         </member>
-        <member name="M:Nanook.GrindCore.ZStd.ZStdEncoder.#ctor(System.Int32,System.Int32,System.Int32,System.Int32,System.Byte[])">
+        <member name="M:Nanook.GrindCore.ZStd.ZStdEncoder.#ctor(System.Int32,System.Int32,System.Int32,System.Int32,System.Byte[],System.Int32)">
             <summary>
             Initializes a new instance of the <see cref="T:Nanook.GrindCore.ZStd.ZStdEncoder"/> class with the specified block size and compression level.
             </summary>
@@ -6408,6 +6413,7 @@
             <param name="nbWorkers">Number of worker threads for multithreaded compression (0 = single-threaded).</param>
             <param name="jobSize">Size of each compression job when using MT (0 = auto).</param>
             <param name="dictionary">Optional pre-trained dictionary data for improved compression.</param>
+            <param name="windowLog">Optional advanced windowLog override for the dictionary's CDict (0 = zstd's implicit level-based sizing, which caps out at 8MB for dictionaries &gt;256KB - see <see cref="P:Nanook.GrindCore.CompressionDictionaryOptions.WindowBits"/>).</param>
         </member>
         <member name="M:Nanook.GrindCore.ZStd.ZStdEncoder.EncodeData(Nanook.GrindCore.CompressionBuffer,Nanook.GrindCore.CompressionBuffer,System.Boolean,Nanook.GrindCore.CancellableTask)">
             <summary>

--- a/src/ZStd/ZStdBlock.cs
+++ b/src/ZStd/ZStdBlock.cs
@@ -38,6 +38,27 @@ namespace Nanook.GrindCore.ZStd
             // read-only/thread-safe per zstd's own docs, so this instance can also be shared read-only across threads that
             // each create their own context per call (as OnCompress/OnDecompress already do).
             bool isV152 = options.Version != null && options.Version.Index == 1;
+
+            // WindowBits doubles as the advanced windowLog override for CDict creation: zstd's own
+            // ZSTD_createCDict() sizes its window from a level-keyed table that caps out at 8MB for any
+            // dictionary >256KB at level 19 and never grows further, regardless of how much bigger the
+            // dictionary actually is. 0 (the default when WindowBits is unset) preserves that exact
+            // implicit behavior - the native side takes the plain ZSTD_createCDict() path for windowLog
+            // <= 0 (and separately, zstd's own ZSTD_c_windowLog documents 0 as "use default" too, so this
+            // is consistent either way). An explicit WindowBits is clamped into zstd's actual valid range
+            // [10, 31] first - zstd's docs require windowLog "clamped between ZSTD_WINDOWLOG_MIN and
+            // ZSTD_WINDOWLOG_MAX", and don't promise to do that clamping themselves - same range already
+            // used below for the output-buffer-size calc, kept consistent here.
+            int windowLog = 0;
+            if (options.Dictionary?.WindowBits != null)
+            {
+                windowLog = options.Dictionary.WindowBits.Value;
+                if (windowLog < 10)
+                    windowLog = 10;
+                if (windowLog > 31)
+                    windowLog = 31;
+            }
+
             if (options.InitProperties != null && options.InitProperties.Length > 0)
             {
                 fixed (byte* dictPtr = options.InitProperties)
@@ -45,7 +66,7 @@ namespace Nanook.GrindCore.ZStd
                     if (isV152)
                     {
                         var cdict152 = new Interop.SZ_ZStd_v1_5_2_CompressionDict();
-                        if (Interop.ZStd_v1_5_2.SZ_ZStd_v1_5_2_CreateCompressionDict(&cdict152, (IntPtr)dictPtr, (UIntPtr)options.InitProperties.Length, _compressionLevel) == 0)
+                        if (Interop.ZStd_v1_5_2.SZ_ZStd_v1_5_2_CreateCompressionDict(&cdict152, (IntPtr)dictPtr, (UIntPtr)options.InitProperties.Length, _compressionLevel, windowLog) == 0)
                             _cdict152 = cdict152;
 
                         var ddict152 = new Interop.SZ_ZStd_v1_5_2_DecompressionDict();
@@ -55,7 +76,7 @@ namespace Nanook.GrindCore.ZStd
                     else
                     {
                         var cdict = new Interop.SZ_ZStd_v1_5_7_CompressionDict();
-                        if (Interop.ZStd.SZ_ZStd_v1_5_7_CreateCompressionDict(&cdict, (IntPtr)dictPtr, (UIntPtr)options.InitProperties.Length, _compressionLevel) == 0)
+                        if (Interop.ZStd.SZ_ZStd_v1_5_7_CreateCompressionDict(&cdict, (IntPtr)dictPtr, (UIntPtr)options.InitProperties.Length, _compressionLevel, windowLog) == 0)
                             _cdict = cdict;
 
                         var ddict = new Interop.SZ_ZStd_v1_5_7_DecompressionDict();
@@ -68,15 +89,7 @@ namespace Nanook.GrindCore.ZStd
             // Resolve input block size: prefer Dictionary.WindowBits -> 1<<WindowBits, otherwise use options.BlockSize. Be tolerant.
             long isize = 0;
             if (options.Dictionary?.WindowBits != null)
-            {
-                int wb = options.Dictionary.WindowBits.Value;
-                if (wb < 10)
-                    wb = 10; // minimum reasonable for zstd
-                if (wb > 31)
-                    wb = 31; // clamp
-                long calc = 1L << wb;
-                isize = calc;
-            }
+                isize = 1L << windowLog; // windowLog is already clamped to [10, 31] above
 
             if (isize == 0)
             {

--- a/src/ZStd/ZStdEncoder.cs
+++ b/src/ZStd/ZStdEncoder.cs
@@ -36,7 +36,8 @@ namespace Nanook.GrindCore.ZStd
         /// <param name="nbWorkers">Number of worker threads for multithreaded compression (0 = single-threaded).</param>
         /// <param name="jobSize">Size of each compression job when using MT (0 = auto).</param>
         /// <param name="dictionary">Optional pre-trained dictionary data for improved compression.</param>
-        public ZStdEncoder(int blockSize, int compressionLevel = 3, int nbWorkers = 0, int jobSize = 0, byte[]? dictionary = null)
+        /// <param name="windowLog">Optional advanced windowLog override for the dictionary's CDict (0 = zstd's implicit level-based sizing, which caps out at 8MB for dictionaries &gt;256KB - see <see cref="CompressionDictionaryOptions.WindowBits"/>).</param>
+        public ZStdEncoder(int blockSize, int compressionLevel = 3, int nbWorkers = 0, int jobSize = 0, byte[]? dictionary = null, int windowLog = 0)
         {
             _compressionLevel = compressionLevel;
             _ctx = new SZ_ZStd_v1_5_7_CompressionContext();
@@ -58,7 +59,7 @@ namespace Nanook.GrindCore.ZStd
                     fixed (byte* dictPtr = dictionary)
                     {
                         SZ_ZStd_v1_5_7_CompressionDict dict = new SZ_ZStd_v1_5_7_CompressionDict();
-                        if (Interop.ZStd.SZ_ZStd_v1_5_7_CreateCompressionDict(&dict, (IntPtr)dictPtr, (UIntPtr)dictionary.Length, _compressionLevel) == 0)
+                        if (Interop.ZStd.SZ_ZStd_v1_5_7_CreateCompressionDict(&dict, (IntPtr)dictPtr, (UIntPtr)dictionary.Length, _compressionLevel, windowLog) == 0)
                         {
                             _cdict = dict;
                             Interop.ZStd.SZ_ZStd_v1_5_7_SetCompressionDict(ctxPtr, &dict);
@@ -197,7 +198,7 @@ namespace Nanook.GrindCore.ZStd
         private SZ_ZStd_v1_5_2_CompressionContext _ctx152;
         private SZ_ZStd_v1_5_2_CompressionDict? _cdict152;
 
-        public ZStdEncoderV1_5_2(int blockSize, int compressionLevel = 3, int nbWorkers = 0, int jobSize = 0, byte[]? dictionary = null)
+        public ZStdEncoderV1_5_2(int blockSize, int compressionLevel = 3, int nbWorkers = 0, int jobSize = 0, byte[]? dictionary = null, int windowLog = 0)
             : base(0, compressionLevel) // base will not be used, but must be called
         {
             _compressionLevel = compressionLevel;
@@ -220,7 +221,7 @@ namespace Nanook.GrindCore.ZStd
                     fixed (byte* dictPtr = dictionary)
                     {
                         SZ_ZStd_v1_5_2_CompressionDict dict = new SZ_ZStd_v1_5_2_CompressionDict();
-                        if (Interop.ZStd_v1_5_2.SZ_ZStd_v1_5_2_CreateCompressionDict(&dict, (IntPtr)dictPtr, (UIntPtr)dictionary.Length, _compressionLevel) == 0)
+                        if (Interop.ZStd_v1_5_2.SZ_ZStd_v1_5_2_CreateCompressionDict(&dict, (IntPtr)dictPtr, (UIntPtr)dictionary.Length, _compressionLevel, windowLog) == 0)
                         {
                             _cdict152 = dict;
                             Interop.ZStd_v1_5_2.SZ_ZStd_v1_5_2_SetCompressionDict(ctxPtr, &dict);

--- a/src/ZStd/ZStdStream.cs
+++ b/src/ZStd/ZStdStream.cs
@@ -46,6 +46,7 @@ namespace Nanook.GrindCore.ZStd
             int resolvedCompressionLevel = options?.Dictionary?.Strategy ?? (int)this.CompressionType;
 
             int resolvedBlockSize = BufferThreshold; // default
+            int resolvedWindowLog = 0; // 0 = zstd's implicit level-based CDict window sizing (see ZStdBlock/CreateCompressionDict)
             if (options?.Dictionary?.WindowBits != null)
             {
                 int wb = options.Dictionary.WindowBits.Value;
@@ -57,6 +58,7 @@ namespace Nanook.GrindCore.ZStd
                 long bs = 1L << wb;
                 if (bs > int.MaxValue) bs = int.MaxValue;
                 resolvedBlockSize = (int)bs;
+                resolvedWindowLog = wb;
             }
 
             if (IsCompress)
@@ -81,9 +83,9 @@ namespace Nanook.GrindCore.ZStd
                 byte[]? dictionary = options?.InitProperties;
 
                 if (useV152)
-                    _encoder = new ZStdEncoderV1_5_2(resolvedBlockSize, resolvedCompressionLevel, nbWorkers, jobSize, dictionary);
+                    _encoder = new ZStdEncoderV1_5_2(resolvedBlockSize, resolvedCompressionLevel, nbWorkers, jobSize, dictionary, resolvedWindowLog);
                 else
-                    _encoder = new ZStdEncoder(resolvedBlockSize, resolvedCompressionLevel, nbWorkers, jobSize, dictionary);
+                    _encoder = new ZStdEncoder(resolvedBlockSize, resolvedCompressionLevel, nbWorkers, jobSize, dictionary, resolvedWindowLog);
                 _buffer = new CompressionBuffer(this.BufferSizeOutput);
             }
             else

--- a/tests/GrindCore.Tests/BZip2MultiStreamTests.cs
+++ b/tests/GrindCore.Tests/BZip2MultiStreamTests.cs
@@ -1,0 +1,136 @@
+using GrindCore.Tests.Utility;
+using Nanook.GrindCore;
+using Nanook.GrindCore.BZip2;
+using System;
+using System.IO;
+using Xunit;
+
+namespace GrindCore.Tests
+{
+    /// <summary>
+    /// Exercises BZip2Decoder's transparent multi-stream (concatenated .bz2) continuation -
+    /// distinct from an ordinary round-trip test, which never produces more than one logical
+    /// bzip2 stream and so never exercises this path. bzip2 has documented concatenation as
+    /// valid input since 0.9.0 (the same convention gzip uses for concatenated members).
+    /// </summary>
+    public sealed class BZip2MultiStreamTests
+    {
+        /// <summary>
+        /// Compresses two independent chunks as two separate, complete bzip2 streams (each with
+        /// its own "BZh" header and end-of-stream marker), concatenates the compressed bytes, and
+        /// confirms decompression transparently continues past the first stream's end and
+        /// produces the concatenation of both original chunks.
+        /// </summary>
+        [Fact]
+        public void BZip2Block_ConcatenatedStreams_DecompressAsOneLogicalStream()
+        {
+            byte[] chunkA = TestDataStream.Create(50_000);
+            byte[] chunkB = TestPseudoTextStream.Create(30_000);
+
+            byte[] compressedA = compressBlock(chunkA);
+            byte[] compressedB = compressBlock(chunkB);
+
+            // Simulate an externally concatenated .bz2 file (e.g. `cat a.bz2 b.bz2 > combined.bz2`).
+            byte[] combined = new byte[compressedA.Length + compressedB.Length];
+            Buffer.BlockCopy(compressedA, 0, combined, 0, compressedA.Length);
+            Buffer.BlockCopy(compressedB, 0, combined, compressedA.Length, compressedB.Length);
+
+            byte[] expected = new byte[chunkA.Length + chunkB.Length];
+            Buffer.BlockCopy(chunkA, 0, expected, 0, chunkA.Length);
+            Buffer.BlockCopy(chunkB, 0, expected, chunkA.Length, chunkB.Length);
+
+            using (var ms = new MemoryStream(combined))
+            using (var stream = new BZip2Stream(ms, CompressionOptions.DefaultDecompress()))
+            using (var outMs = new MemoryStream())
+            {
+                stream.CopyTo(outMs);
+                byte[] actual = outMs.ToArray();
+
+                Assert.Equal(expected.Length, actual.Length);
+                Assert.True(actual.AsSpan().SequenceEqual(expected), "Decompressed concatenated streams did not match the concatenation of the original chunks.");
+            }
+        }
+
+        /// <summary>
+        /// Same as above but with three concatenated streams, confirming the continuation logic
+        /// isn't limited to a single reinitialization.
+        /// </summary>
+        [Fact]
+        public void BZip2Block_ThreeConcatenatedStreams_DecompressAsOneLogicalStream()
+        {
+            byte[][] chunks =
+            {
+                TestDataStream.Create(20_000),
+                TestNonCompressibleDataStream.Create(15_000),
+                TestPseudoTextStream.Create(25_000)
+            };
+
+            using (var combinedMs = new MemoryStream())
+            {
+                foreach (byte[] chunk in chunks)
+                {
+                    byte[] compressed = compressBlock(chunk);
+                    combinedMs.Write(compressed, 0, compressed.Length);
+                }
+
+                byte[] expected = new byte[chunks[0].Length + chunks[1].Length + chunks[2].Length];
+                int pos = 0;
+                foreach (byte[] chunk in chunks)
+                {
+                    Buffer.BlockCopy(chunk, 0, expected, pos, chunk.Length);
+                    pos += chunk.Length;
+                }
+
+                combinedMs.Position = 0;
+                using (var stream = new BZip2Stream(combinedMs, CompressionOptions.DefaultDecompress()))
+                using (var outMs = new MemoryStream())
+                {
+                    stream.CopyTo(outMs);
+                    byte[] actual = outMs.ToArray();
+
+                    Assert.Equal(expected.Length, actual.Length);
+                    Assert.True(actual.AsSpan().SequenceEqual(expected), "Decompressed 3-way concatenated streams did not match the concatenation of the original chunks.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// A single (non-concatenated) stream must still decompress normally - confirms the
+        /// magic-byte probe that decides whether to continue after BZ_STREAM_END doesn't
+        /// misbehave when there simply is no more data.
+        /// </summary>
+        [Fact]
+        public void BZip2Block_SingleStream_DecompressesNormally()
+        {
+            byte[] chunk = TestDataStream.Create(10_000);
+            byte[] compressed = compressBlock(chunk);
+
+            using (var ms = new MemoryStream(compressed))
+            using (var stream = new BZip2Stream(ms, CompressionOptions.DefaultDecompress()))
+            using (var outMs = new MemoryStream())
+            {
+                stream.CopyTo(outMs);
+                byte[] actual = outMs.ToArray();
+
+                Assert.Equal(chunk.Length, actual.Length);
+                Assert.True(actual.AsSpan().SequenceEqual(chunk));
+            }
+        }
+
+        private static byte[] compressBlock(byte[] data)
+        {
+            using (CompressionBlock block = CompressionBlockFactory.Create(CompressionAlgorithm.BZip2, CompressionType.Optimal, data.Length, false, null))
+            {
+                byte[] compressed = BufferPool.Rent(block.RequiredCompressOutputSize);
+                int compressedLength = compressed.Length;
+                var result = block.Compress(data, 0, data.Length, compressed, 0, ref compressedLength);
+                Assert.Equal(CompressionResultCode.Success, result);
+
+                byte[] trimmed = new byte[compressedLength];
+                Buffer.BlockCopy(compressed, 0, trimmed, 0, compressedLength);
+                BufferPool.Return(compressed);
+                return trimmed;
+            }
+        }
+    }
+}

--- a/tests/GrindCore.Tests/CompressionBlockTests.cs
+++ b/tests/GrindCore.Tests/CompressionBlockTests.cs
@@ -70,6 +70,9 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, CompressionVersion.ZSTD_v1_5_2, 0x195, "3545b23ad651d5d4")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, CompressionVersion.ZSTD_v1_5_2, 0x195, "3545b23ad651d5d4")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, CompressionVersion.ZSTD_v1_5_2, 0x195, "3545b23ad651d5d4")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, null, 0x4eb, "c365a915aa207c65")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, null, 0x4eb, "0a74debb4a7dbc63")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, null, 0x4eb, "0a74debb4a7dbc63")]
         public void Data_ByteArray64KiB_BlockCompress(CompressionAlgorithm algorithm, CompressionType type, string? version, int size, string expected)
         {
             using (CompressionBlock block = CompressionBlockFactory.Create(algorithm, type, _Data64KiB.Length, false, CompressionVersion.Create(algorithm, version)))
@@ -133,6 +136,9 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, 0x1000a, "4b9f7d6be30a4eca")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, 0x1000a, "4b9f7d6be30a4eca")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, 0x1000a, "4b9f7d6be30a4eca")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, 0x10281, "e66ecbf6abdf847a")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, 0x10281, "35496d2fa0b23389")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, 0x10281, "35496d2fa0b23389")]
         public void DataNonCompressible_ByteArray64KiB_BlockCompress(CompressionAlgorithm algorithm, CompressionType type, int size, string expected)
         {
             using (CompressionBlock block = CompressionBlockFactory.Create(algorithm, type, _DataNC64KiB.Length, false, CompressionVersion.Create(algorithm)))
@@ -162,6 +168,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Fastest, null, 0x2651, "8b0b438386b0c1f5")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, null, 0x83a, "8a7fd9bf458ad52a")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, CompressionVersion.ZSTD_v1_5_2, 0x83a, "8a7fd9bf458ad52a")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, null, 0xe6f, "d070588a52f991f6")]
 
 #if !IS_32BIT
         [InlineData(CompressionAlgorithm.Lz4, CompressionType.Fastest, null, 0x16d9, "f9420ec7af17eccf")]
@@ -177,6 +184,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Optimal, null, 0xbe7, "bd93e4482eb778cb")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, null, 0x7f0, "8723d465c72e2e88")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, CompressionVersion.ZSTD_v1_5_2, 0x7f0, "8723d465c72e2e88")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, null, 0xe6f, "29d0774cc96ce8de")]
 
         [InlineData(CompressionAlgorithm.Brotli, CompressionType.SmallestSize, null, 0x4fa, "bd7a15fc895f1b65")]
         [InlineData(CompressionAlgorithm.Deflate, CompressionType.SmallestSize, null, 0xb9b, "080ef351410b77ac")]
@@ -189,6 +197,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.SmallestSize, null, 0xba1, "2b9ecf7dce8e81ce")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, null, 0x5c0, "6775dd2c3d7c5222")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, CompressionVersion.ZSTD_v1_5_2, 0x714, "fd2c3ec61fa17a6a")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, null, 0xe6f, "29d0774cc96ce8de")]
 #endif
         public void Text_ByteArray64KiB(CompressionAlgorithm algorithm, CompressionType type, string? version, int size, string expected)
         {

--- a/tests/GrindCore.Tests/CompressionStreamTests.cs
+++ b/tests/GrindCore.Tests/CompressionStreamTests.cs
@@ -24,6 +24,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Fastest, 0x3d3, "faf781046fb77de8")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Fastest, 0x4c5, "1c5c2490ab900308")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, 0x197, "e6b4aafc1efa2266")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, 0x4eb, "c365a915aa207c65")]
 
 #if !IS_32BIT
         [InlineData(CompressionAlgorithm.Lz4, CompressionType.Fastest, 0x29a, "72f75d0b96ea09ee")]
@@ -38,6 +39,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Optimal, 0x305, "a3c36ab37f8f236d")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Optimal, 0x305, "a3c36ab37f8f236d")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, 0x197, "7dd3bfedab192873")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, 0x4eb, "0a74debb4a7dbc63")]
 
         [InlineData(CompressionAlgorithm.Brotli, CompressionType.SmallestSize, 0x18a, "03e8b1d250f7e6aa")]
         [InlineData(CompressionAlgorithm.Deflate, CompressionType.SmallestSize, 0x2ff, "fd1a57a63d29c607")]
@@ -49,6 +51,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.SmallestSize, 0x305, "a21b9fa33c110bc5")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.SmallestSize, 0x305, "a21b9fa33c110bc5")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, 0x197, "6f32a8f86c2c0f8b")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, 0x4eb, "0a74debb4a7dbc63")]
 #endif
         public void Data_Stream64KiB(CompressionAlgorithm algorithm, CompressionType type, int compressedSize, string compXxH64)
         {
@@ -77,6 +80,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Fastest, 0x8, "2bc964c3d0162760")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Fastest, 0x8, "2bc964c3d0162760")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, 0x9, "ea7ad91258c4ea87")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, 0xe, "e0c95a86158b3e4e")]
 
 #if !IS_32BIT
         [InlineData(CompressionAlgorithm.Lz4, CompressionType.Fastest, 0xb, "9810acdea8d71804")]
@@ -91,6 +95,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Optimal, 0x8, "65f2e912ed28c1ed")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Optimal, 0x8, "65f2e912ed28c1ed")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, 0x9, "22c883899be40e7c")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, 0xe, "30bd3c7bff035e20")]
 
         [InlineData(CompressionAlgorithm.Brotli, CompressionType.SmallestSize, 0x1, "12f83c352a398165")]
         [InlineData(CompressionAlgorithm.Deflate, CompressionType.SmallestSize, 0x2, "fae4a10ff02fd326")]
@@ -102,6 +107,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.SmallestSize, 0x8, "31edcf2ea90ea820")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.SmallestSize, 0x8, "31edcf2ea90ea820")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, 0x9, "8559f845bc0c4f54")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, 0xe, "30bd3c7bff035e20")]
 #endif
         public void Text_StreamEmpty(CompressionAlgorithm algorithm, CompressionType type, int compressedSize, string compXxH64)
         {
@@ -131,6 +137,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Fastest, null, 0x2652, "f2324065e2e34d09")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, null, 0x827, "6227887e1bc483a0")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, CompressionVersion.ZSTD_v1_5_2, 0x827, "6227887e1bc483a0")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, null, 0xe6f, "d070588a52f991f6")]
 #if !IS_32BIT
         [InlineData(CompressionAlgorithm.Lz4, CompressionType.Fastest, null, 0x16e8, "a0783a6c336c8bd9")]
 
@@ -145,6 +152,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Optimal, null, 0xbe7, "bd93e4482eb778cb")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, null, 0x7f2, "b18fa96dc3b4708d")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, CompressionVersion.ZSTD_v1_5_2, 0x7f2, "b18fa96dc3b4708d")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, null, 0xe6f, "29d0774cc96ce8de")]
 
         [InlineData(CompressionAlgorithm.Brotli, CompressionType.SmallestSize, null, 0x4fa, "bd7a15fc895f1b65")]
         [InlineData(CompressionAlgorithm.Deflate, CompressionType.SmallestSize, null, 0xb9b, "080ef351410b77ac")]
@@ -157,6 +165,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.SmallestSize, null, 0xba1, "2b9ecf7dce8e81ce")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, null, 0x561, "dcff6b04d3f0e324")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, CompressionVersion.ZSTD_v1_5_2, 0x6bd, "085483666aa6a09f")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, null, 0xe6f, "29d0774cc96ce8de")]
 #endif
         public void Text_Stream64KiB(CompressionAlgorithm algorithm, CompressionType type, string? version, int compressedSize, string compXxH64)
         {
@@ -187,6 +196,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Fastest, 0x600781, "6aaba9c27838a268", "4d650db1242fefec")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Fastest, 0x654019, "6aaba9c27838a268", "503de593cc2df76a")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, 0x600099, "6aaba9c27838a268", "d033cda5805f142b")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, 0x60c5b3, "6aaba9c27838a268", "527b7474191fe530")]
         public void DataNonCompressible_Stream6MiB_Chunk1MiB(CompressionAlgorithm algorithm, CompressionType type, long compressedSize, string rawXxh64, string compXxH64)
         {
             int streamLen = 6 * 1024 * 1024; // Total bytes to process
@@ -217,6 +227,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Level0, 0x6001eb, "5cb9b63eb9a4c344", "0a28fcae3b408197")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Level0, 0x6001eb, "5cb9b63eb9a4c344", "0a28fcae3b408197")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Level0, 0x5717, "5cb9b63eb9a4c344", "425403335cb3485b")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Level0, 0x394d3, "5cb9b63eb9a4c344", "d84ba25966b65739")]
         public void NoCompression_Stream6MiB_Chunk1MiB(CompressionAlgorithm algorithm, CompressionType type, long compressedSize, string rawXxh64, string compXxH64)
         {
             int streamLen = 6 * 1024 * 1024; // Total bytes to process
@@ -247,6 +258,7 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZLib, CompressionType.Fastest, 0xb49f, "7833322f45651d24", "6971719677322556")]
         [InlineData(CompressionAlgorithm.ZLibNg, CompressionType.Fastest, 0x13723, "7833322f45651d24", "34a0eaac76a7fd87")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, 0x3d4, "7833322f45651d24", "ae6f556cb2489ead")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, 0x1272a, "7833322f45651d24", "e2bb5072a530fe22")]
         public void Data_Stream6MiB_ReadByteWriteByte(CompressionAlgorithm algorithm, CompressionType type, long compressedSize, string rawXxH64, string compXxH64)
         {
             int streamLen = 6 * 1024 * 1024; // Total bytes to process
@@ -298,6 +310,9 @@ namespace GrindCore.Tests
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Fastest, 0x90b, "6d522dca7d96dfe8", "5690b6b13a63fa53")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.Optimal, 0x90b, "6d522dca7d96dfe8", "8c2c44e66f7f5ff0")]
         [InlineData(CompressionAlgorithm.ZStd, CompressionType.SmallestSize, 0x86e, "6d522dca7d96dfe8", "060d59864bfd9550")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Fastest, 0x3d782, "6d522dca7d96dfe8", "3ebd03ad440ca8fe")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.Optimal, 0x87cc, "6d522dca7d96dfe8", "1cf8f83efea14312")]
+        [InlineData(CompressionAlgorithm.BZip2, CompressionType.SmallestSize, 0x87cc, "6d522dca7d96dfe8", "1cf8f83efea14312")]
         public async Task Data_Stream20MiB_Chunk1MiB_Async(CompressionAlgorithm algorithm, CompressionType type, long compressedSize, string rawXxH64, string compXxH64)
         {
             int streamLen = 20 * 1024 * 1024; // Total bytes to process

--- a/tests/GrindCore.Tests/SharpCompressIntegration/BZip2Stream_GC.cs
+++ b/tests/GrindCore.Tests/SharpCompressIntegration/BZip2Stream_GC.cs
@@ -1,0 +1,303 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SharpCompress.Compressors;
+using SharpCompress.Providers;
+
+#if GRINDCORE
+using Nanook.GrindCore;
+using GrindCoreBZip2Stream = Nanook.GrindCore.BZip2.BZip2Stream;
+#endif
+
+namespace SharpCompress.Compressors.BZip2;
+
+/// <summary>
+/// Lightweight wrapper for GrindCore BZip2Stream that implements SharpCompress's real
+/// BZip2Stream API shape (Create/CreateAsync factories + IFinishable + IAsyncDisposable), so
+/// this file is a drop-in replacement for SharpCompress.Compressors.BZip2.BZip2Stream (see
+/// GrindCore.SharpCompress/src/SharpCompress/Compressors/BZip2/BZip2Stream.cs and
+/// BZip2Stream.Async.cs) rather than mirroring LZ4Stream_GC's plain-constructor, sync-only shape.
+/// Re-verified against GrindCore.SharpCompress @ 2c2e2760 ("Update to latest SharpCompress
+/// v0.50.4") after the fork was resynced with upstream. The ValueTask/IAsyncDisposable-based
+/// members (CreateAsync/IsBZip2Async/FinishAsync/DisposeAsync/Memory{T} Read/WriteAsync) are only
+/// available on netstandard2.1+/netcoreapp3.0+ - net48 has no ValueTask/IAsyncDisposable without
+/// a polyfill package this project doesn't reference (matching every other _GC.cs shim here,
+/// which are sync-only for the same reason); the byte[]-based Task ReadAsync/WriteAsync overrides
+/// remain available everywhere since Stream has provided those since .NET 4.5.
+/// </summary>
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+public sealed class BZip2Stream : Stream, IFinishable, IAsyncDisposable
+#else
+public sealed class BZip2Stream : Stream, IFinishable
+#endif
+{
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets the compression mode this stream was created with.
+    /// </summary>
+    public CompressionMode Mode { get; }
+
+#if GRINDCORE
+    private readonly GrindCoreBZip2Stream _grindCoreStream;
+
+    private BZip2Stream(Stream baseStream, CompressionMode compressionMode, bool leaveOpen)
+    {
+        Mode = compressionMode;
+        _grindCoreStream = new GrindCoreBZip2Stream(baseStream, new CompressionOptions
+        {
+            // GrindCore's BZip2Stream has no separate "level" concept exposed here beyond
+            // Optimal/SmallestSize/Fastest resolving to bzip2's blockSize100k - Optimal (which
+            // resolves to level 9, matching bzip2's own CLI default) is the sensible default for
+            // a generic Create() call with no level parameter, mirroring SharpCompress's own
+            // BZip2CompressionProvider which ignores compressionLevel for BZip2 entirely.
+            Type = compressionMode == CompressionMode.Compress
+                ? Nanook.GrindCore.CompressionType.Optimal
+                : Nanook.GrindCore.CompressionType.Decompress,
+            LeaveOpen = leaveOpen
+        });
+    }
+#else
+    private BZip2Stream(Stream baseStream, CompressionMode compressionMode, bool leaveOpen)
+    {
+        throw new NotSupportedException("BZip2 compression requires GrindCore library");
+    }
+#endif
+
+    /// <summary>
+    /// Creates a BZip2Stream backed by GrindCore.
+    /// </summary>
+    /// <param name="stream">The stream to read from (decompress) or write to (compress).</param>
+    /// <param name="compressionMode">Compression or decompression mode.</param>
+    /// <param name="decompressConcatenated">
+    /// Accepted for API compatibility with SharpCompress's own BZip2Stream.Create signature, but
+    /// has no effect here - GrindCore's BZip2Decoder always transparently continues past a
+    /// stream boundary into concatenated bzip2 data (multi-stream .bz2) when the following bytes
+    /// look like another bzip2 header; there is no separate "stop at first stream end" mode to
+    /// opt out of.
+    /// </param>
+    /// <param name="leaveOpen">Whether to leave the base stream open when disposing.</param>
+    /// <param name="tolerateTruncatedStream">
+    /// Not currently honored - GrindCore's decoder has no way to distinguish "clean EOF at a
+    /// bzip2 block boundary" from any other truncation at the native BZ2_bzDecompress level (both
+    /// surface as BZ_UNEXPECTED_EOF), so a genuinely truncated stream will still throw
+    /// InvalidDataException regardless of this flag. Accepted only so callers written against
+    /// the real BZip2Stream.Create signature still compile against this shim.
+    /// </param>
+    public static BZip2Stream Create(
+        Stream stream,
+        CompressionMode compressionMode,
+        bool decompressConcatenated,
+        bool leaveOpen = false,
+        bool tolerateTruncatedStream = false) => new BZip2Stream(stream, compressionMode, leaveOpen);
+
+    /// <summary>
+    /// Consumes two bytes to test if there is a BZip2 header ("BZ").
+    /// </summary>
+    public static bool IsBZip2(Stream stream)
+    {
+        int b0 = stream.ReadByte();
+        int b1 = stream.ReadByte();
+        return b0 == 'B' && b1 == 'Z';
+    }
+
+    /// <summary>
+    /// Finalizes compression, flushing any remaining buffered data and the bzip2 stream trailer.
+    /// </summary>
+    public void Finish()
+    {
+#if GRINDCORE
+        _grindCoreStream?.Complete();
+#endif
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    /// <summary>
+    /// Creates a BZip2Stream backed by GrindCore. GrindCore's own stream construction never
+    /// performs I/O up front (unlike CBZip2InputStream.CreateAsync, which peeks the header), so
+    /// this simply calls the synchronous <see cref="Create"/> and returns a completed ValueTask -
+    /// provided for API compatibility with the real BZip2Stream.CreateAsync signature.
+    /// </summary>
+    public static ValueTask<BZip2Stream> CreateAsync(
+        Stream stream,
+        CompressionMode compressionMode,
+        bool decompressConcatenated,
+        bool leaveOpen = false,
+        bool tolerateTruncatedStream = false,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<BZip2Stream>(Create(stream, compressionMode, decompressConcatenated, leaveOpen, tolerateTruncatedStream));
+    }
+
+    /// <summary>
+    /// Asynchronously consumes two bytes to test if there is a BZip2 header ("BZ").
+    /// </summary>
+    public static async ValueTask<bool> IsBZip2Async(Stream stream, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        byte[] buffer = new byte[2];
+        int bytesRead = await stream.ReadAsync(buffer, 0, 2, cancellationToken).ConfigureAwait(false);
+        return bytesRead >= 2 && buffer[0] == (byte)'B' && buffer[1] == (byte)'Z';
+    }
+
+    /// <summary>
+    /// Asynchronously finalizes compression. Use this instead of <see cref="Finish"/> when
+    /// writing to an async-only stream.
+    /// </summary>
+    public async ValueTask FinishAsync(CancellationToken cancellationToken = default)
+    {
+#if GRINDCORE
+        if (_grindCoreStream != null)
+            await _grindCoreStream.CompleteAsync().ConfigureAwait(false);
+#else
+        await Task.CompletedTask.ConfigureAwait(false);
+#endif
+    }
+#endif
+
+    public override bool CanRead =>
+#if GRINDCORE
+        _grindCoreStream?.CanRead ?? false;
+#else
+        false;
+#endif
+
+    public override bool CanSeek =>
+#if GRINDCORE
+        _grindCoreStream?.CanSeek ?? false;
+#else
+        false;
+#endif
+
+    public override bool CanWrite =>
+#if GRINDCORE
+        _grindCoreStream?.CanWrite ?? false;
+#else
+        false;
+#endif
+
+    public override long Length =>
+#if GRINDCORE
+        _grindCoreStream?.Length ?? 0;
+#else
+        throw new NotSupportedException();
+#endif
+
+    public override long Position
+    {
+        get =>
+#if GRINDCORE
+            _grindCoreStream?.Position ?? 0;
+#else
+            throw new NotSupportedException();
+#endif
+        set =>
+#if GRINDCORE
+            _grindCoreStream.Position = value;
+#else
+            throw new NotSupportedException();
+#endif
+    }
+
+    public override void Flush()
+    {
+#if GRINDCORE
+        _grindCoreStream?.Flush();
+#endif
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+#if GRINDCORE
+        return _grindCoreStream?.Read(buffer, offset, count) ?? 0;
+#else
+        throw new NotSupportedException("BZip2 compression requires GrindCore library");
+#endif
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+#if GRINDCORE
+        return _grindCoreStream?.Seek(offset, origin) ?? 0;
+#else
+        throw new NotSupportedException();
+#endif
+    }
+
+    public override void SetLength(long value)
+    {
+#if GRINDCORE
+        _grindCoreStream?.SetLength(value);
+#else
+        throw new NotSupportedException();
+#endif
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+#if GRINDCORE
+        _grindCoreStream?.Write(buffer, offset, count);
+#else
+        throw new NotSupportedException("BZip2 compression requires GrindCore library");
+#endif
+    }
+
+#if GRINDCORE && (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+        _grindCoreStream!.ReadAsync(buffer, cancellationToken);
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+        _grindCoreStream!.WriteAsync(buffer, cancellationToken);
+#endif
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+#if GRINDCORE
+        return _grindCoreStream!.ReadAsync(buffer, offset, count, cancellationToken);
+#else
+        throw new NotSupportedException("BZip2 compression requires GrindCore library");
+#endif
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+#if GRINDCORE
+        return _grindCoreStream!.WriteAsync(buffer, offset, count, cancellationToken);
+#else
+        throw new NotSupportedException("BZip2 compression requires GrindCore library");
+#endif
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!_disposed && disposing)
+        {
+#if GRINDCORE
+            // _grindCoreStream itself already respects the LeaveOpen option passed at
+            // construction (it only disposes the wrapped base stream when LeaveOpen is false),
+            // matching the real BZip2Stream's current shape where leaveOpen lives on the wrapped
+            // CBZip2Input/OutputStream rather than being special-cased here.
+            _grindCoreStream?.Dispose();
+#endif
+            _disposed = true;
+        }
+        base.Dispose(disposing);
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_disposed)
+        {
+            _disposed = true;
+#if GRINDCORE
+            if (_grindCoreStream != null)
+                await _grindCoreStream.DisposeAsync().ConfigureAwait(false);
+#endif
+        }
+        GC.SuppressFinalize(this);
+    }
+#endif
+}

--- a/tests/GrindCore.Tests/SharpCompressIntegration/BZip2Stream_GC_Tests.cs
+++ b/tests/GrindCore.Tests/SharpCompressIntegration/BZip2Stream_GC_Tests.cs
@@ -1,0 +1,102 @@
+using GrindCore.Tests.Utility;
+using SharpCompress.Compressors;
+using SharpCompress.Compressors.BZip2;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GrindCore.Tests.SharpCompressIntegration
+{
+    /// <summary>
+    /// Exercises the SharpCompress-compatible BZip2Stream shim (BZip2Stream_GC.cs) end-to-end,
+    /// confirming it's usable as a drop-in for SharpCompress.Compressors.BZip2.BZip2Stream
+    /// through its real Create/Finish/IsBZip2 API surface, not just that it compiles.
+    /// </summary>
+    public sealed class BZip2Stream_GC_Tests
+    {
+        [Fact]
+        public void CompressThenDecompress_RoundTrips()
+        {
+            byte[] data = TestPseudoTextStream.Create(64 * 1024);
+
+            byte[] compressed;
+            using (var ms = new MemoryStream())
+            {
+                using (var bz = BZip2Stream.Create(ms, CompressionMode.Compress, decompressConcatenated: false, leaveOpen: true))
+                {
+                    bz.Write(data, 0, data.Length);
+                    bz.Finish();
+                }
+                compressed = ms.ToArray();
+            }
+
+            Assert.True(BZip2Stream.IsBZip2(new MemoryStream(compressed)), "Compressed output should start with a BZip2 (\"BZ\") header.");
+
+            using (var ms = new MemoryStream(compressed))
+            using (var bz = BZip2Stream.Create(ms, CompressionMode.Decompress, decompressConcatenated: false))
+            using (var outMs = new MemoryStream())
+            {
+                bz.CopyTo(outMs);
+                byte[] result = outMs.ToArray();
+
+                Assert.Equal(data.Length, result.Length);
+                Assert.True(result.AsSpan().SequenceEqual(data));
+            }
+        }
+
+        [Fact]
+        public void IsBZip2_RejectsNonBZip2Data()
+        {
+            byte[] notBzip2 = { 0x00, 0x01, 0x02, 0x03 };
+            Assert.False(BZip2Stream.IsBZip2(new MemoryStream(notBzip2)));
+        }
+
+        [Fact]
+        public void Mode_ReflectsConstructionParameter()
+        {
+            using (var ms = new MemoryStream())
+            using (var bz = BZip2Stream.Create(ms, CompressionMode.Compress, decompressConcatenated: false, leaveOpen: true))
+                Assert.Equal(CompressionMode.Compress, bz.Mode);
+        }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public async Task CompressThenDecompress_Async_RoundTrips()
+        {
+            byte[] data = TestPseudoTextStream.Create(64 * 1024);
+
+            byte[] compressed;
+            using (var ms = new MemoryStream())
+            {
+                await using (var bz = await BZip2Stream.CreateAsync(ms, CompressionMode.Compress, decompressConcatenated: false, leaveOpen: true))
+                {
+                    await bz.WriteAsync(data, 0, data.Length);
+                    await bz.FinishAsync();
+                }
+                compressed = ms.ToArray();
+            }
+
+            Assert.True(await BZip2Stream.IsBZip2Async(new MemoryStream(compressed)));
+
+            using (var ms = new MemoryStream(compressed))
+            await using (var bz = await BZip2Stream.CreateAsync(ms, CompressionMode.Decompress, decompressConcatenated: false))
+            using (var outMs = new MemoryStream())
+            {
+                await bz.CopyToAsync(outMs);
+                byte[] result = outMs.ToArray();
+
+                Assert.Equal(data.Length, result.Length);
+                Assert.True(result.AsSpan().SequenceEqual(data));
+            }
+        }
+
+        [Fact]
+        public async Task IsBZip2Async_RejectsNonBZip2Data()
+        {
+            byte[] notBzip2 = { 0x00, 0x01, 0x02, 0x03 };
+            Assert.False(await BZip2Stream.IsBZip2Async(new MemoryStream(notBzip2)));
+        }
+#endif
+    }
+}

--- a/tests/GrindCore.Tests/SharpCompressIntegration/Dependencies/IFinishable.cs
+++ b/tests/GrindCore.Tests/SharpCompressIntegration/Dependencies/IFinishable.cs
@@ -1,0 +1,19 @@
+namespace SharpCompress.Providers;
+
+/// <summary>
+/// Interface for compression streams that require explicit finalization
+/// before disposal to ensure all compressed data is flushed properly.
+/// </summary>
+/// <remarks>
+/// Some compression formats (notably BZip2 and LZip) require explicit
+/// finalization to write trailer/footer data. Implementing this interface
+/// allows generic code to handle finalization without knowing the specific stream type.
+/// </remarks>
+public interface IFinishable
+{
+    /// <summary>
+    /// Finalizes the compression, flushing any remaining buffered data
+    /// and writing format-specific trailer/footer bytes.
+    /// </summary>
+    void Finish();
+}

--- a/tests/GrindCore.Tests/ZStdDictionaryTests.cs
+++ b/tests/GrindCore.Tests/ZStdDictionaryTests.cs
@@ -133,6 +133,77 @@ namespace GrindCore.Tests
         }
 
         [Theory]
+        [InlineData("record-301", "explicit windowLog override, v1.5.7")]
+        public void ZStdBlock_Dictionary_ExplicitWindowBits_RoundTrip(string id, string body)
+        {
+            // Regression coverage for the windowLog gap: ZSTD_createCDict()'s implicit sizing caps the
+            // window at 8MB for any dictionary >256KB at level 19 and never grows further, no matter how
+            // much bigger the dictionary actually gets - CreateCompressionDict now takes an explicit
+            // windowLog (sourced from Dictionary.WindowBits) to override that. This dictionary is nowhere
+            // near 8MB, so this isn't proving a ratio improvement - it's proving the advanced
+            // ZSTD_createCDict_advanced2 code path round-trips correctly at all when WindowBits is set,
+            // which nothing previously exercised (WindowBits was only ever used for output-buffer sizing).
+            byte[] data = buildRecord(id, body);
+
+            var options = new CompressionOptions
+            {
+                Type = CompressionType.Optimal,
+                BlockSize = data.Length,
+                InitProperties = Dictionary,
+                Dictionary = new CompressionDictionaryOptions { WindowBits = 24 } // 16MB - comfortably above the 8MB implicit cap
+            };
+
+            using (var block = new ZStdBlock(options))
+            {
+                byte[] compressed = new byte[block.RequiredCompressOutputSize];
+                int compressedLength = compressed.Length;
+                var compressResult = block.Compress(data, 0, data.Length, compressed, 0, ref compressedLength);
+                Assert.Equal(CompressionResultCode.Success, compressResult);
+
+                byte[] decompressed = new byte[data.Length];
+                int decompressedLength = decompressed.Length;
+                var decompressResult = block.Decompress(compressed, 0, compressedLength, decompressed, 0, ref decompressedLength);
+                Assert.Equal(CompressionResultCode.Success, decompressResult);
+
+                Assert.Equal(data.Length, decompressedLength);
+                Assert.Equal(data, decompressed);
+            }
+        }
+
+        [Theory]
+        [InlineData("record-302", "explicit windowLog override, v1.5.2")]
+        public void ZStdBlock_Dictionary_V1_5_2_ExplicitWindowBits_RoundTrip(string id, string body)
+        {
+            // Same rationale as the v1.5.7 test above, exercised against the v1.5.2 advanced2 code path.
+            byte[] data = buildRecord(id, body);
+
+            var options = new CompressionOptions
+            {
+                Type = CompressionType.Optimal,
+                BlockSize = data.Length,
+                Version = CompressionVersion.ZStd(ZStdVersion.v1_5_2),
+                InitProperties = Dictionary,
+                Dictionary = new CompressionDictionaryOptions { WindowBits = 24 }
+            };
+
+            using (var block = new ZStdBlock(options))
+            {
+                byte[] compressed = new byte[block.RequiredCompressOutputSize];
+                int compressedLength = compressed.Length;
+                var compressResult = block.Compress(data, 0, data.Length, compressed, 0, ref compressedLength);
+                Assert.Equal(CompressionResultCode.Success, compressResult);
+
+                byte[] decompressed = new byte[data.Length];
+                int decompressedLength = decompressed.Length;
+                var decompressResult = block.Decompress(compressed, 0, compressedLength, decompressed, 0, ref decompressedLength);
+                Assert.Equal(CompressionResultCode.Success, decompressResult);
+
+                Assert.Equal(data.Length, decompressedLength);
+                Assert.Equal(data, decompressed);
+            }
+        }
+
+        [Theory]
         [InlineData("record-101", "delta payload for the streaming round trip")]
         [InlineData("record-102", "epsilon payload, a little longer to span more than one internal buffer flush")]
         public void ZStdStream_Dictionary_RoundTrip(string id, string body)


### PR DESCRIPTION
## Summary

Two independent changes bundled on this branch:

1. **ZStd `windowLog` advanced override**, threaded through to
   `CompressionDictionaryOptions.WindowBits`.
2. **New `Nanook.GrindCore.BZip2` codec** (block + streaming), on top of the
   new native `SZ_BZip2_v1_0_8_*` entrypoints (native PR: Nanook/GrindCore#5).

### 1. ZStd `windowLog` override

Closes a gap where `ZStdBlock`'s dictionary path had no way to override
zstd's implicit level-based window sizing — at level 19, dictionaries
larger than 256KB were capped at windowLog 23 (8MB) no matter how much
bigger the dictionary got, putting a hard ceiling on compression ratio for
larger dictionaries.

- `Interop.ZStd.cs`: both `SZ_ZStd_v1_5_7_CreateCompressionDict` and
  `SZ_ZStd_v1_5_2_CreateCompressionDict` P/Invoke signatures gained an
  `int windowLog` parameter.
- `ZStdBlock.cs`: computes a clamped `windowLog` (range
  `[ZSTD_WINDOWLOG_MIN=10, ZSTD_WINDOWLOG_MAX]`) once from
  `options.Dictionary.WindowBits` and passes it through to
  `CreateCompressionDict` — also fixed a pre-existing bug where the raw
  unclamped `WindowBits` was being passed as `windowLog` directly, which
  could violate zstd's minimum for values 1-9.
- `ZStdStream.cs`/`ZStdEncoder.cs`: same clamped `windowLog` threaded
  through the streaming dictionary path for consistency.
- Added `ZStdDictionaryTests.cs` cases exercising an explicit `WindowBits`
  larger than the default level-19 tier would allow.

### 2. BZip2 codec

- `Interop.BZip2.cs`, `BZip2Block/Encoder/Decoder/Stream.cs`, following the
  existing per-codec pattern.
- Registered in `CompressionAlgorithm`, `CompressionBlockFactory`,
  `CompressionStreamFactory`, `CompressionType` (`MaxBZip2`),
  `CompressionDefaults`, `CompressionVersion`.
- Adds `WorkFactor`/`SmallDecompress` to `CompressionDictionaryOptions`.
- Supports multi-stream (concatenated `.bz2`) decompression transparently —
  tested in `BZip2MultiStreamTests.cs`.
- Adds a SharpCompress-compatible `BZip2Stream_GC.cs` shim under
  `tests/GrindCore.Tests/SharpCompressIntegration/`, matching the real
  `SharpCompress.Compressors.BZip2.BZip2Stream` API shape (`Create`/
  `CreateAsync`, `IFinishable`, `IAsyncDisposable`).

**Implementation note**: the streaming context (`BZip2Encoder`/
`BZip2Decoder`) is allocated in unmanaged memory rather than held as a
plain managed struct field: libbzip2 stores the exact `bz_stream*` pointer
passed to `BZ2_bzCompressInit`/`BZ2_bzDecompressInit` and rejects any later
call whose pointer doesn't match — a managed struct field's address isn't
guaranteed stable across separate P/Invoke calls under a compacting GC.

## Verification

- Golden-value test rows added to `CompressionBlockTests.cs`/
  `CompressionStreamTests.cs` for BZip2.
- BZip2 cross-verified against Python's independent `bz2` module —
  byte-identical compressed output, and correct decompression in both
  directions — rather than relying on purely self-referential
  round-tripping.
- Full suite passing (1116/1116 at last full run, net8.0 and net48 both
  verified).
- Version bumped 0.8.1 → 0.8.2 (patch), matching this project's precedent
  of treating even a full new codec as patch-level.

Depends on the native codec landing first: Nanook/GrindCore#5
